### PR TITLE
tests dir should not contain __init__.py

### DIFF
--- a/pyscaffold/structure.py
+++ b/pyscaffold/structure.py
@@ -84,7 +84,7 @@ def make_structure(args):
         args.package: {"__init__.py": templates.init(args),
                        "skeleton.py": templates.skeleton(args),
                        "_version.py": templates.version(args)},
-        "tests": {"__init__.py": ""},
+        "tests": {"conftest.py": ""},
         "docs": {"conf.py": templates.sphinx_conf(args),
                  "authors.rst": templates.sphinx_authors(args),
                  "index.rst": templates.sphinx_index(args),


### PR DESCRIPTION
According to the pytest docs, the tests directory should not contain an __init__.py (then it is possible to run tests on other versions or releases of pyscaffold and test wheel releases which do not distribute the tests).

Instead a conftest.py is created. This file is used by pytest to share test fixtures, etc.