### PR TITLE
Update error message as this failure can be caused by distribute too

### DIFF
--- a/pyscaffold/utils.py
+++ b/pyscaffold/utils.py
@@ -227,7 +227,7 @@ def prepare_namespace(namespace_str):
 
 
 def check_setuptools_version():
-    """Checks that setuptools has all necessary capabilities for setuptools_scm
+    """Check that setuptools has all necessary capabilities for setuptools_scm
 
     Raises:
           :obj:`RuntimeError` : raised if necessary capabilities are not met
@@ -236,5 +236,7 @@ def check_setuptools_version():
         from pkg_resources import parse_version, SetuptoolsVersion  # noqa
     except ImportError:
         raise RuntimeError(
-            "Your setuptools version is too old (<12).\n"
-            "Use `pip install -U setuptools` to upgrade.")
+            "Your setuptools version is too old (<12). "
+            "Use `pip install -U setuptools` to upgrade.\n"
+            "If you have the deprecated `distribute` package installed "
+            "remove it or update to version 0.7.3.")


### PR DESCRIPTION
An ImportError can be raised here when the python package distribute
is too old too, not just setuptools:

```
    Installed /tmp/pip-build-NuXIK3/stratosphere-client/setuptools_scm-1.8.0-py2.7.egg
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-NuXIK3/stratosphere-client/setup.py", line 24, in <module>
        setup_package()
      File "/tmp/pip-build-NuXIK3/stratosphere-client/setup.py", line 20, in setup_package
        use_pyscaffold=True)
      File "/usr/lib/python2.7/distutils/core.py", line 112, in setup
        _setup_distribution = dist = klass(attrs)
      File "/home/vagrant/.virtualenvs/ansible/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/setuptools/dist.py", line 225, in __init__
        _Distribution.__init__(self,attrs)
      File "/usr/lib/python2.7/distutils/dist.py", line 287, in __init__
        self.finalize_options()
      File "/home/vagrant/.virtualenvs/ansible/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/setuptools/dist.py", line 258, in finalize_options
        ep.load()(self, ep.name, value)
      File "/tmp/pip-build-NuXIK3/stratosphere-client/PyScaffold-2.5b2-py2.7.egg/pyscaffold/integration.py", line 104, in pyscaffold_keyword
        check_setuptools_version()
      File "/tmp/pip-build-NuXIK3/stratosphere-client/PyScaffold-2.5b2-py2.7.egg/pyscaffold/utils.py", line 210, in check_setuptools_version
        "ERROR: Your setuptools version is too old (<12).\n"
    RuntimeError: ERROR: Your setuptools version is too old (<12).
    Use `pip install -U setuptools` to upgrade.

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-NuXIK3/stratosphere-client
(ansible)vagrant@precise64:~/airflow:master  X $ python
Python 2.7.3 (default, Jun 22 2015, 19:33:41)
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from pkg_resources import parse_version, SetuptoolsVersion
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name SetuptoolsVersion
>>> quit()
(ansible)vagrant@precise64:~/airflow:master  X $ pip install -U distribute
/home/vagrant/.virtualenvs/ansible/local/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:90: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
Collecting distribute
  Using cached distribute-0.7.3.zip
Requirement already up-to-date: setuptools>=0.7 in /home/vagrant/.virtualenvs/ansible/lib/python2.7/site-packages (from distribute)
Installing collected packages: distribute
  Found existing installation: distribute 0.6.24
    Uninstalling distribute-0.6.24:
      Successfully uninstalled distribute-0.6.24
  Running setup.py install for distribute
Successfully installed distribute-0.7.3
(ansible)vagrant@precise64:~/airflow:master  X $ python
Python 2.7.3 (default, Jun 22 2015, 19:33:41)
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from pkg_resources import parse_version, SetuptoolsVersion
>>> quit()
(ansible)vagrant@precise64:~/airflow:master  X $
```
