### PR TITLE
Fix miniconda install path to not depend on upstream consistency

### DIFF
--- a/pyscaffold/templates/travis_install.template
+++ b/pyscaffold/templates/travis_install.template
@@ -19,8 +19,8 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # itself
     wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
         -O miniconda.sh
-    chmod +x miniconda.sh && ./miniconda.sh -b
-    export PATH=/home/travis/miniconda/bin:$PATH
+    chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+    export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
 
     # Configure the conda environment and put it in the path using the

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -42,8 +42,8 @@ if [[ "${DISTRIB}" == "conda" ]]; then
     # itself
     wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
         -O miniconda.sh
-    chmod +x miniconda.sh && ./miniconda.sh -b
-    export PATH=/home/travis/miniconda/bin:$PATH
+    chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+    export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
 
     # Configure the conda environment and put it in the path using the


### PR DESCRIPTION
- currently miniconda for Python2.x installs into `miniconda2`
  by default which breaks this script