### PR TITLE
update PATH to match Miniconda2 envs

### DIFF
--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -43,7 +43,7 @@ if [[ "${DISTRIB}" == "conda" ]]; then
     wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
         -O miniconda.sh
     chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
-    export PATH=$HOME/miniconda/bin:$PATH
+    export PATH=$HOME/miniconda2/bin:$PATH
     conda update --yes conda
 
     # Configure the conda environment and put it in the path using the


### PR DESCRIPTION
Hi! 

When ``PATH`` in ``tests/travis_install.sh`` is set according to ``export PATH=$HOME/miniconda/bin:$PATH`` then Travis fail with error:

```
tests/travis_install.sh: line 24: conda: command not found
```

for builds with ``DISTRIB="conda"``.

Changing to ``export PATH=$HOME/miniconda2/bin:$PATH`` resolves the issue

