### PR TITLE
Query effective rather than global git configuration

### DIFF
--- a/pyscaffold/info.py
+++ b/pyscaffold/info.py
@@ -26,7 +26,7 @@ def username():
     :return: user's name as string
     """
     try:
-        user = next(shell.git("config", "--global", "--get", "user.name"))
+        user = next(shell.git("config", "--get", "user.name"))
         user = user.strip()
     except CalledProcessError:
         user = getpass.getuser()
@@ -40,7 +40,7 @@ def email():
     :return: user's email as string
     """
     try:
-        email = next(shell.git("config", "--global", "--get", "user.email"))
+        email = next(shell.git("config", "--get", "user.email"))
         email = email.strip()
     except CalledProcessError:
         user = getpass.getuser()
@@ -70,7 +70,7 @@ def is_git_configured():
     """
     try:
         for attr in ["name", "email"]:
-            shell.git("config", "--global", "--get", "user.{}".format(attr))
+            shell.git("config", "--get", "user.{}".format(attr))
     except CalledProcessError:
         return False
     return True


### PR DESCRIPTION
Recent versions of git support [additional configuration files](https://git-scm.com/docs/git-config#FILES) e.g. `$XDG_CONFIG_HOME/git/config`. When setting `user.name` and `user.email` in this file (as I do), it is not reported by `git config --global`.

I don't really see a reason to explicitly query the *global* git configuration instead of the *effective* git configuration, which is what a plain `git config user.name` does.