### PR TITLE
Adds --with-vagrant option

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Developers
 * Florian Rathgeber <florian.rathgeber@gmail.com>
 * Eva Schmücker <email@evaschmuecker.de>
 * Tim Werner <tim.werner@blue-yonder.com>
+* Brian Bruggeman <brian.m.bruggeman@gmail.com>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 2.5.6, 2016-??-??
 
 - Prefix error message with ERROR:
 - Suffix of untagged commits changed from {version}-{hash} to {version}-n{hash}
+- Adds support for vagrant (--with-vagrant)
 
 Version 2.5.5, 2016-02-26
 =========================

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Build the documentation with ``python setup.py docs`` and run doctests with
 extend the documentation. The documentation also works with `Read the Docs
 <https://readthedocs.org/>`_.
 
-The `Numpy and Google style docstrings 
+The `Numpy and Google style docstrings
 <http://sphinx-doc.org/latest/ext/napoleon.html>`_ are activated by default.
 Just make sure Sphinx 1.3 or above is installed.
 
@@ -137,6 +137,14 @@ With the help of `Cookiecutter <https://cookiecutter.readthedocs.org/>`_ it
 is possible to customize your project setup. Just use the flag
 ``--with-cookiecutter TEMPLATE`` to use a cookiecutter template which will be
 refined by PyScaffold afterwards.
+
+
+Vagrant
+=======
+
+Creates a `Vagrant <https://www.vagrantup.com>`_ folder within the project
+with a vagrant build as specified by the flag ``--with-vagrant`` which
+is equivalent to running ``cd vagrant && vagrant init my_vagrant_box``.
 
 
 Easy Updating

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -32,6 +32,10 @@ Just a few examples to get you an idea of how easy PyScaffold is to use:
   and ``.travis.yml`` for `Tox <http://tox.testrun.org/>`_ and
   `Travis <https://travis-ci.org/>`_.
 
+``putup virtual_machine --with-vagrant debian/jessie64``
+  This will create a project and package *virtual_machine* with files ``vagrant/Vagrantfile``
+  for `Vagrant <https://www.vagrantup.com/>`_.
+
 ``putup my_zope_subpackage --with-namespace zope -l gpl3``
   This will create a project and subpackage named *my_zope_subpackage* in the
   namespace *zope*. To be honest, there is really only the `Zope project <http://www.zope.org/>`_

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -168,6 +168,15 @@ is possible to customize your project setup. Just use the flag
 refined by PyScaffold afterwards.
 
 
+Vagrant
+=======
+
+Creates a `Vagrant <https://www.vagrantup.com>`_ folder within the project
+with a vagrant build as specified by the flag ``--with-vagrant`` which
+is equivalent to running ``cd vagrant && vagrant init my_vagrant_box``.
+
+
+
 Easy Updating
 =============
 

--- a/pyscaffold/cli.py
+++ b/pyscaffold/cli.py
@@ -117,6 +117,12 @@ def parse_args(args):
         action="store_true",
         default=False,
         help="generate Tox configuration file")
+    parser.add_argument(
+        "--with-vagrant",
+        dest="vagrant",
+        default="",
+        help="generate vagrant folder (e.g. debian/jessie64)",
+        metavar="DISTRO/VERSION")
 
     version = pyscaffold.__version__
     parser.add_argument('-v',
@@ -221,6 +227,8 @@ def make_sanity_checks(opts):
             '  git config --global user.email "you@example.com"\n' +
             '  git config --global user.name "Your Name"\n' +
             "to set your account's default identity.")
+    if opts['vagrant'] and not info.is_vagrant_installed():
+        raise RuntimeError("Make sure vagrant is installed and working.")
     if os.path.exists(opts['project']):
         if not opts['update'] and not opts['force']:
             raise RuntimeError(

--- a/pyscaffold/info.py
+++ b/pyscaffold/info.py
@@ -78,6 +78,21 @@ def is_git_configured():
     return True
 
 
+def is_vagrant_installed():
+    """
+    Check if vagrant is installed
+
+    :return: boolean
+    """
+    if shell.vagrant is None:
+        return False
+    try:
+        shell.vagrant("--version")
+    except CalledProcessError:
+        return False
+    return True
+
+
 def project(opts):
     """
     Update user options with the options of an existing PyScaffold project

--- a/pyscaffold/shell.py
+++ b/pyscaffold/shell.py
@@ -87,3 +87,7 @@ git = get_git_cmd()
 
 #: Command for django-admin.py
 django_admin = ShellCommand("django-admin.py")
+
+# Command for vagrant
+vagrant = ShellCommand("vagrant")
+

--- a/pyscaffold/structure.py
+++ b/pyscaffold/structure.py
@@ -87,6 +87,8 @@ def make_structure(opts):
         proj_dir['.pre-commit-config.yaml'] = templates.pre_commit_config(opts)
     if opts['tox']:
         proj_dir['tox.ini'] = templates.tox(opts)
+    if opts['vagrant']:
+        proj_dir.setdefault('vagrant', {})['Vagrantfile'] = templates.vagrant(opts)
     if opts['update'] and not opts['force']:
         # Do not overwrite following files
         rules = {opts['project']: {

--- a/pyscaffold/templates/__init__.py
+++ b/pyscaffold/templates/__init__.py
@@ -329,3 +329,14 @@ def conftest_py(opts):
     """
     template = get_template("conftest_py")
     return template.substitute(opts)
+
+
+def vagrant(opts):
+    """
+    Template of vagrant
+
+    :param opts: mapping parameters as a dictionary
+    :return: file content as string
+    """
+    template = get_template("vagrant")
+    return template.substitute(opts)

--- a/pyscaffold/templates/vagrant.template
+++ b/pyscaffold/templates/vagrant.template
@@ -1,0 +1,55 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# This plugin updates the host environment with named ip addresses
+unless Vagrant.has_plugin?("vagrant-hosts")
+  raise 'vagrant-hosts is not installed. Please run: vagrant plugin install vagrant-hosts'
+end
+
+# Modify this to virtualbox, parallels, qemu, aws, etc. if a change is desired
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'virtualbox'
+
+Vagrant.configure(2) do |config|
+  # Specify which vagrant box to use here
+  config.vm.box = "${vagrant}"
+
+  # Update the local host environment so it can be accessed through named ip
+  #  addresses
+  config.vm.provision :hosts do |provisioner|
+    config.vm.provider :virtualbox do |vbox, override|
+      provisioner.add_host '192.168.100.100', ['${package}', '${package}.loc', '${package}.local', '${package}.dev']
+    end
+  end
+
+  # Create a box named '${package}'
+  config.vm.define "${package}" do |${package}|
+
+    # Provide shared access to repo within vm under /repos/${package}
+    ${package}.vm.provider "virtualbox" do |vbox, override|
+      override.vm.synced_folder "../.", "/repos/${package}", create: true
+    end
+
+    # Assign ip address and name
+    ${package}.vm.hostname = "${package}.loc"
+    ${package}.vm.provider "virtualbox" do |vbox, override|
+      override.vm.network "private_network", ip: "192.168.100.100"
+      override.vm.network "forwarded_port", guest: 4000, host: 4000
+    end
+
+    # Do provisioning here
+    # ${package}.vm.provision "ansible" do |ansible|
+    #   # ansible.verbose = ""
+    #   ansible.playbook = "ansible/{package}.yml"
+    # end
+    # ${package}.vm.provision :shell, path: "bootstrap_${package}.sh", privileged: false
+
+  end
+
+  # Create multi-box scenario here
+  #   Don't forget to update the provider.add_host above
+  # config.vm.define "new_box" do |new_box|
+  #   ...
+  # end
+end
+
+

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -5,7 +5,7 @@ from os.path import isdir, isfile
 
 import pytest
 import six
-from pyscaffold import cli, structure, utils
+from pyscaffold import cli, structure, utils, info
 
 __author__ = "Florian Wilhelm"
 __copyright__ = "Blue Yonder"
@@ -92,6 +92,32 @@ def test_make_structure_with_tox():
     assert isinstance(struct, dict)
     assert "tox.ini" in struct["project"]
     assert isinstance(struct["project"]["tox.ini"], six.string_types)
+
+
+@pytest.mark.xfail(not info.is_vagrant_installed(),
+                   reason="Requires vagrant to be installed")
+def test_make_structure_with_vagrant():
+    args = ["project",
+            "-p", "package",
+            "-d", "description",
+            "--with-vagrant", "debian/jessie64"]
+    opts = cli.parse_args(args)
+    opts = cli.get_default_opts(opts['project'], **opts)
+    struct = structure.make_structure(opts)
+    assert isinstance(struct, dict)
+    assert "Vagrantfile" in struct["project"]["vagrant"]
+    assert isinstance(struct["project"]["vagrant"]["Vagrantfile"], six.string_types)
+
+
+def test_make_structure_without_vagrant():
+    args = ["project",
+            "-p", "package",
+            "-d", "description"]
+    opts = cli.parse_args(args)
+    opts = cli.get_default_opts(opts['project'], **opts)
+    struct = structure.make_structure(opts)
+    assert isinstance(struct, dict)
+    assert "vagrant" not in struct["project"]
 
 
 def test_apply_update_rules(tmpdir):  # noqa


### PR DESCRIPTION
Motivation:

I am often building packages for an environment (debian8) that does not match my local box (a mac). Consequently, I generally add a virtual machine provisioner (vagrant) to my package.

It appears that the testing is failing due to a library not being available on the pandas build (ARM), which is unrelated to this specific change.