### PR TITLE
Travis template: move miniconda download location

### DIFF
--- a/pyscaffold/templates/travis_install.template
+++ b/pyscaffold/templates/travis_install.template
@@ -17,9 +17,13 @@ if [[ "$DISTRIB" == "conda" ]]; then
 
     # Use the miniconda installer for faster download / install of conda
     # itself
+    DOWNLOAD_DIR=$HOME/download
+    mkdir -p $DOWNLOAD_DIR
     wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh \
-        -O miniconda.sh
-    chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+        -O $DOWNLOAD_DIR/miniconda.sh
+    chmod +x $DOWNLOAD_DIR/miniconda.sh && \
+        bash $DOWNLOAD_DIR/miniconda.sh -b -p $HOME/miniconda && \
+        rm -r -d -f $DOWNLOAD_DIR
     export PATH=$HOME/miniconda/bin:$PATH
     conda update --yes conda
 


### PR DESCRIPTION
Fixes #107 by adding a temporary directory (stored in `DOWNLOAD_DIR` env var) which holds the `miniconda.sh` binary during installation, removing the directory after successful install.