### PR TITLE
Fix #96 for PyScaffold and README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Unittest & Coverage
 Run ``python setup.py test`` to run all unittests defined in the subfolder
 ``tests`` with the help of `py.test <http://pytest.org/>`_ and
 `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`_. Some sane
-default flags for py.test are already defined in the ``[pytest]`` section of
+default flags for py.test are already defined in the ``[tool:pytest]`` section of
 ``setup.cfg``. The py.test plugin
 `pytest-cov <https://github.com/schlamar/pytest-cov>`_ is used to automatically
 generate a coverage report. It is also possible to provide additional

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ ALL =
 # py.test options when running `python setup.py test`
 addopts = tests --verbose
 
-[pytest]
+[tool:pytest]
 # Options for py.test:
 # Specify command line options as you would do when invoking py.test directly.
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml


### PR DESCRIPTION
* PyScaffold itself still used `[pytest]` and not `[tool:pytest]` in its ``setup.cfg``
* The `README.rst` also referred to `[pytest]`