### PR TITLE
Add support for GitLab-CI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 2.5.8, 2017-??-??
 =========================
 
 - Use `sphinx.ext.imgmath` instead of `sphinx.ext.mathjax`
+- Add `--with-gitlab-ci` flag
 
 Version 2.5.7, 2016-10-11
 =========================

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,8 @@ templates of the `Travis <https://travis-ci.org/>`_ configuration files
 coverage and stats system `Coveralls <https://coveralls.io/>`_.
 In order to use the virtualenv management and test tool `Tox
 <https://tox.readthedocs.org/>`_ the flag ``--with-tox`` can be specified.
+If you prefer to use `GitLab-CI <https://gitlab.com>`_ then you can use the flag
+``--with-gitlab-ci`` to get a ``.gitlab-ci.yml`` configuration.
 
 
 Management of Requirements & Licenses

--- a/pyscaffold/cli.py
+++ b/pyscaffold/cli.py
@@ -108,6 +108,12 @@ def parse_args(args):
         default=False,
         help="generate Travis configuration files")
     parser.add_argument(
+        "--with-gitlab-ci",
+        dest="gitlab_ci",
+        action="store_true",
+        default=False,
+        help="generate GitLab-CI configuration files")
+    parser.add_argument(
         "--with-pre-commit",
         dest="pre_commit",
         action="store_true",

--- a/pyscaffold/structure.py
+++ b/pyscaffold/structure.py
@@ -86,6 +86,8 @@ def make_structure(opts):
     if opts['travis']:
         proj_dir['.travis.yml'] = templates.travis(opts)
         proj_dir['tests']['travis_install.sh'] = templates.travis_install(opts)
+    if opts['gitlab_ci']:
+        proj_dir['.gitlab-ci.yml'] = templates.gitlab_ci(opts)
     if opts['pre_commit']:
         proj_dir['.pre-commit-config.yaml'] = templates.pre_commit_config(opts)
     if opts['tox']:
@@ -103,6 +105,7 @@ def make_structure(opts):
             'requirements.txt': FileOp.NO_OVERWRITE,
             'test-requirements.txt': FileOp.NO_OVERWRITE,
             '.travis.yml': FileOp.NO_OVERWRITE,
+            '.gitlab-ci.yml': FileOp.NO_OVERWRITE,
             '.coveragerc': FileOp.NO_OVERWRITE,
             '.pre-commit-config.yaml': FileOp.NO_OVERWRITE,
             'tox.ini': FileOp.NO_OVERWRITE,

--- a/pyscaffold/templates/__init__.py
+++ b/pyscaffold/templates/__init__.py
@@ -265,6 +265,17 @@ def travis_install(opts):
     return template.safe_substitute(opts)
 
 
+def gitlab_ci(opts):
+    """
+    Template of .gitlab-ci.yml
+
+    :param opts: mapping parameters as dictionary
+    :return: file content as string
+    """
+    template = get_template("gitlab_ci")
+    return template.safe_substitute(opts)
+
+
 def pre_commit_config(opts):
     """
     Template of .pre-commit-config.yaml

--- a/pyscaffold/templates/gitlab_ci.template
+++ b/pyscaffold/templates/gitlab_ci.template
@@ -1,0 +1,74 @@
+# This file is a template, and might need editing before it works on your project.
+# Official language image. Look for the different tagged releases at:
+# image: "python:2.7"
+
+# Pick zero or more services to be used on all builds.
+# Only needed when using a docker container to run your tests in.
+# Check out: http://docs.gitlab.com/ce/ci/docker/using_docker_images.html#what-is-service
+#services:
+#  - mysql:latest
+#  - redis:latest
+#  - postgres:latest
+
+#variables:
+#  POSTGRES_DB: database_name
+
+# Cache packages in between builds
+cache:
+  paths:
+    - vendor/python
+
+# This is a basic example for a packages or script which doesn't use
+# services such as redis or postgres
+before_script:
+  - python -v                                   # Print out Python version for debugging
+  # Setup git
+  - apt-get install git
+  - git config --global user.email "you@example.com"
+  - git config --global user.name "Your Name"
+  # Install dependencies of your package and the testing environment
+  - pip install -r requirements.txt
+  - pip install -r test-requirements.txt
+
+# Run in different environments
+py27:
+  image: "python:2.7"
+  script:
+  - python setup.py test
+
+py33:
+  image: "python:3.3"
+  script:
+  - python setup.py test
+
+py34:
+  image: "python:3.4"
+  script:
+  - python setup.py test
+
+py35:
+  image: "python:3.5"
+  script:
+  - python setup.py test
+
+py36:
+  image: "python:3.6"
+  script:
+  - python setup.py test
+
+cov:
+  script:
+  - py.test --cov=cassandra tests
+
+docs:
+  script:
+  - python setup.py docs
+
+# This deploy job uses a simple deploy flow to Heroku, other providers, e.g. AWS Elastic Beanstalk
+# are supported too: https://github.com/travis-ci/dpl
+#deploy:
+#  type: deploy
+#  environment: production
+#  script:
+#  - python setup.py 
+#  - dpl --provider=heroku --app=$HEROKU_APP_NAME --api-key=$HEROKU_PRODUCTION_KEY

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,6 +104,10 @@ def test_with_travis(tmpdir):  # noqa
     cli.run()
 
 
+def test_with_gitlab(tmpdir):  # noqa
+    sys.argv = ["pyscaffold", "--with-gitlab-ci", "my_project"]
+    cli.run()
+
 def test_with_namespaces(tmpdir):  # noqa
     sys.argv = ["pyscaffold", "--with-namespace", "com.blue_yonder",
                 "my_project"]


### PR DESCRIPTION
* A new flag `--with-gitlab-ci` lets PyScaffold create a
``.gitlab-ci.yml`` as an example for `GitLab <https://gitlab.com>`_ CI's configuration.

* The ``.gitlab-ci.yml``-template is based on the official ruby template, since there was no Python template in the GitLab instances I am using.
* The implementation is similar to `travis.yml`'s implementation