### PR TITLE
Fix failing coverage and doc builds in the gitlab-ci

### DIFF
--- a/pyscaffold/templates/gitlab_ci.template
+++ b/pyscaffold/templates/gitlab_ci.template
@@ -56,11 +56,9 @@ py36:
   script:
   - python setup.py test
 
-cov:
-  script:
-  - py.test --cov=cassandra tests
-
 docs:
+  before_script:
+  - pip install Sphinx
   script:
   - python setup.py docs
 


### PR DESCRIPTION
I'm sorry I figured out this errors only now when testing your, @FlorianWilhelm, RC1 `2.5.8rc1`. Now everythink should be fine.
Thank you for merging #111 already into the version 2.

Fixes:
* Coverage is run at every test anyways so there is no need for an extra coverage run
* `Sphinx` needed to be installed first, since it is not included in the `test-requirements.txt`