### PR TITLE
Corrected syntax issues with bash file

### DIFF
--- a/pyscaffold/templates/travis_install.template
+++ b/pyscaffold/templates/travis_install.template
@@ -31,9 +31,9 @@ if [[ "$DISTRIB" == "conda" ]]; then
     # provided versions
     conda create -n testenv --yes python=$PYTHON_VERSION pip
     source activate testenv
-
 elif [[ "$DISTRIB" == "ubuntu" ]]; then
     # Use standard ubuntu packages in their default version
+    echo $DISTRIB
 fi
 
 if [[ "$COVERAGE" == "true" ]]; then


### PR DESCRIPTION
Fixes #107, tested using PyScaffold (3.0a2) and on [Travis](https://travis-ci.org/willu47/test_pyscaff)

Removing extra CRLF before `elif` as is content within the `elif`