### PR TITLE
V3.x gitlab ci

### DIFF
--- a/docs/examples/gitlab-ci-extension.rst
+++ b/docs/examples/gitlab-ci-extension.rst
@@ -1,0 +1,4 @@
+GitLab-CI Extension
+===================
+
+.. literalinclude:: ../../pyscaffold/extensions/gitlab_ci.py

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -416,6 +416,7 @@ and can be used as reference implementation:
    --with-pre-commit <examples/pre-commit-extension>
    --with-tox <examples/tox-extension>
    --with-travis <examples/travis-extension>
+   --with-gitlab-ci <examples/gitlab-ci-extension>
 
 
 Conventions for Community Extensions

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -110,6 +110,8 @@ templates of the `Travis <https://travis-ci.org/>`_ configuration files
 coverage and stats system `Coveralls <https://coveralls.io/>`_.
 In order to use the virtualenv management and test tool `Tox
 <https://tox.readthedocs.org/>`_ the flag ``--with-tox`` can be specified.
+If you are using `GitLab <https://gitlab.com/>`_ you can get a default 
+`.gitlab-ci.yml` also running `pytest-cov` with the flag ``--with-gitlab-ci``.
 
 .. rubric:: Managing test environments with tox
 

--- a/pyscaffold/extensions/gitlab_ci.py
+++ b/pyscaffold/extensions/gitlab_ci.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""
+Extension that generates configuration and script files for GitLab CI.
+"""
+from __future__ import absolute_import
+
+from ..templates import gitlab_ci
+
+
+def augment_cli(parser):
+    """Add an option to parser that enables the GitLab CI extension.
+
+    Args:
+        parser (argparse.ArgumentParser): CLI parser object
+    """
+
+    parser.add_argument("--with-gitlab-ci",
+                        dest="extensions",
+                        action="append_const",
+                        const=extend_project,
+                        help="generate GitLab CI configuration files")
+
+
+def extend_project(actions, helpers):
+    """Add GitLab CI specific files to the project structure."""
+
+    def add_gitlab_file(structure, opts):
+        structure = helpers.merge(structure, {
+            opts['project']: {
+                opts['package']: {
+                    '.gitlab-ci.yml', (gitlab_ci(opts), scaffold.NO_OVERWRITE)
+                },
+            }
+        })
+
+        return (helpers.merge(structure, {opts['project']: files}), opts)
+
+    return helpers.register(action, add_gitlab_file)

--- a/pyscaffold/templates/__init__.py
+++ b/pyscaffold/templates/__init__.py
@@ -265,6 +265,17 @@ def travis_install(opts):
     return template.safe_substitute(opts)
 
 
+def gitlab_ci(opts):
+    """
+    Template of .gitlab-ci.yml
+
+    :param opts: mapping parameters as dictionary
+    :return: file content as string
+    """
+    template = get_template("gitlab_ci")
+    return template.safe_substitute(opts)
+
+
 def pre_commit_config(opts):
     """
     Template of .pre-commit-config.yaml

--- a/pyscaffold/templates/gitlab_ci.template
+++ b/pyscaffold/templates/gitlab_ci.template
@@ -1,0 +1,72 @@
+# This file is a template, and might need editing before it works on your project.
+# Official language image. Look for the different tagged releases at:
+# image: "python:2.7"
+
+# Pick zero or more services to be used on all builds.
+# Only needed when using a docker container to run your tests in.
+# Check out: http://docs.gitlab.com/ce/ci/docker/using_docker_images.html#what-is-service
+#services:
+#  - mysql:latest
+#  - redis:latest
+#  - postgres:latest
+
+#variables:
+#  POSTGRES_DB: database_name
+
+# Cache packages in between builds
+cache:
+  paths:
+    - vendor/python
+
+# This is a basic example for a packages or script which doesn't use
+# services such as redis or postgres
+before_script:
+  - python -v                                   # Print out Python version for debugging
+  # Setup git
+  - apt-get install git
+  - git config --global user.email "you@example.com"
+  - git config --global user.name "Your Name"
+  # Install dependencies of your package and the testing environment
+  - pip install -r requirements.txt
+  - pip install -r test-requirements.txt
+
+# Run in different environments
+py27:
+  image: "python:2.7"
+  script:
+  - python setup.py test
+
+py33:
+  image: "python:3.3"
+  script:
+  - python setup.py test
+
+py34:
+  image: "python:3.4"
+  script:
+  - python setup.py test
+
+py35:
+  image: "python:3.5"
+  script:
+  - python setup.py test
+
+py36:
+  image: "python:3.6"
+  script:
+  - python setup.py test
+
+docs:
+  before_script:
+  - pip install Sphinx
+  script:
+  - python setup.py docs
+
+# This deploy job uses a simple deploy flow to Heroku, other providers, e.g. AWS Elastic Beanstalk
+# are supported too: https://github.com/travis-ci/dpl
+#deploy:
+#  type: deploy
+#  environment: production
+#  script:
+#  - python setup.py 
+#  - dpl --provider=heroku --app=$HEROKU_APP_NAME --api-key=$HEROKU_PRODUCTION_KEY

--- a/tests/system_test.sh
+++ b/tests/system_test.sh
@@ -53,6 +53,9 @@ run_common_tasks ${PROJECT}
 rm -rf ${PROJECT}
 putup --with-travis ${PROJECT}
 run_common_tasks ${PROJECT}
+rm -rf ${PROJECT}
+putup --with-gitlab-ci ${PROJECT}
+run_common_tasks ${PROJECT}
 
 # Test Makefile for sphinx
 PROJECT="project_with_docs"


### PR DESCRIPTION
Fixes issue #112

Add the `--gitlab-ci` flag as another example extension.
Documentation also takes `gitlab-ci` as an example of implementing an extension.