### PR TITLE
Update __init__.template

### DIFF
--- a/pyscaffold/templates/__init__.template
+++ b/pyscaffold/templates/__init__.template
@@ -3,5 +3,5 @@ import pkg_resources
 
 try:
     __version__ = pkg_resources.get_distribution(__name__).version
-except:
+except pkg_resources.RequirementParseError:
     __version__ = 'unknown'

--- a/pyscaffold/templates/__init__.template
+++ b/pyscaffold/templates/__init__.template
@@ -3,5 +3,5 @@ import pkg_resources
 
 try:
     __version__ = pkg_resources.get_distribution(__name__).version
-except pkg_resources.RequirementParseError:
+except:  # noqa
     __version__ = 'unknown'


### PR DESCRIPTION
Add the exception name to the except clause since it is is considered best practice [(PEP-8:](https://www.python.org/dev/peps/pep-0008/#id51) "When catching exceptions, mention specific exceptions whenever possible instead of using a bare except: clause.")