### PR TITLE
Update Python versions in tox.ini template

### DIFF
--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -4,7 +4,7 @@
 
 [tox]
 minversion = 1.8
-envlist = py27,py33,py34,flake8
+envlist = py27,py34,py35,py36,flake8
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.3 is outdated since 2017-09-29, but Python 3.6.3 is nearly one year old.