### PR TITLE
Adding setuptools dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ packages = find:
 include_package_data = True
 package_dir =
     =src
+install_requires = setuptools>=30.3.0
 tests_require = pytest; pytest-cov
 
 [options.packages.find]


### PR DESCRIPTION
This PR adds setuptools>=30.3.0 as a dependency during installation to solve issue #155 
