### PR TITLE
Added a namespace cleanup to the __init__.py template

### DIFF
--- a/src/pyscaffold/templates/__init__.template
+++ b/src/pyscaffold/templates/__init__.template
@@ -7,3 +7,5 @@ try:
     __version__ = get_distribution(dist_name).version
 except DistributionNotFound:
     __version__ = 'unknown'
+finally:
+    del get_distribution, DistributionNotFound


### PR DESCRIPTION
This is a merge request related to issue #158.
previously, the in __init__.py template, several names from setuptools
remain in the namespace of the package, which later leakes to whomever
imports the package. Now these names are deleted from the module's
globals before the module finishes loading.