### PR TITLE
Fix pre-commit-config and pre-commit extension templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.py[cod]
 *.so
 *.cfg
+!.isort.cfg
 !setup.cfg
 *.orig
 *.log

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,8 +1,10 @@
 [settings]
 line_length=79
 indent='    '
+skip=src/pyscaffold/contrib,.tox,.venv
 known_compat=six,pkg_resources
 known_test=pytest
 sections=FUTURE,STDLIB,COMPAT,TEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 default_section=THIRDPARTY
 multi_line_output=3
+known_third_party = StringIO,__builtin__,colorama,cookiecutter,demoapp,demoapp_data,future_builtins,nt,pkg_resources,pyscaffold,pytest,setuptools,setuptools_scm,six,sphinx

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,9 +2,10 @@
 line_length=79
 indent='    '
 skip=src/pyscaffold/contrib,.tox,.venv
-known_compat=six,pkg_resources
+known_standard_library=StringIO,__builtin__,setuptools,pkg_resources
+known_compat=six
 known_test=pytest
+known_first_party=pyscaffold
 sections=FUTURE,STDLIB,COMPAT,TEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 default_section=THIRDPARTY
 multi_line_output=3
-known_third_party = StringIO,__builtin__,colorama,cookiecutter,demoapp,demoapp_data,future_builtins,nt,pkg_resources,pyscaffold,pytest,setuptools,setuptools_scm,six,sphinx

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,27 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.8.0
+    sha: v1.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: check-added-large-files
+    -   id: check-ast
     -   id: check-json
-    -   id: check-yaml
+    -   id: check-merge-conflict
     -   id: check-xml
+    -   id: check-yaml
     -   id: debug-statements
     -   id: end-of-file-fixer
     -   id: requirements-txt-fixer
+    -   id: mixed-line-ending
+        args:
+        - --fix=no
     -   id: flake8
         args:
         - --exclude=docs/conf.py
--   repo: git://github.com/FalconSocial/pre-commit-python-sorter
-    sha: 1.0.4
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v1.0.0
     hooks:
-    -   id: python-import-sorter
-        args:
-        - --silent-overwrite
+    -   id: seed-isort-config
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.4
+    hooks:
+    -   id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,6 @@
     -   id: flake8
         args:
         - --exclude=docs/conf.py
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v1.0.0
-    hooks:
-    -   id: seed-isort-config
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.4
     hooks:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -55,6 +55,15 @@ Clone the repository
 #. Run ``python setup.py egg_info --egg-base .`` after a fresh checkout.
    This will generate some critically needed files. Typically after that,
    you should run ``python setup.py develop`` to be able run ``putup``.
+
+#. Install ``pre-commit``::
+
+    pip install pre-commit
+    pre-commit install
+
+   PyScaffold project comes with a lot of hooks configured to
+   automatically help the developer to check the code being written.
+
 #. Create a branch to hold your changes::
 
     git checkout -b my-feature

--- a/src/pyscaffold/extensions/pre_commit.py
+++ b/src/pyscaffold/extensions/pre_commit.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 from ..api import Extension, helpers
 from ..log import logger
-from ..templates import pre_commit_config
+from ..templates import isort_cfg, pre_commit_config
 
 
 class PreCommit(Extension):
@@ -30,6 +30,10 @@ class PreCommit(Extension):
     def add_files(struct, opts):
         """Add .pre-commit-config.yaml file to structure
 
+        Since the default template uses isort, this function also provides an
+        initial version of .isort.cfg that can be extended by the user
+        (it contains some useful skips, e.g. tox and venv)
+
         Args:
             struct (dict): project representation as (possibly) nested
                 :obj:`dict`.
@@ -43,6 +47,9 @@ class PreCommit(Extension):
             '.pre-commit-config.yaml': (
                 pre_commit_config(opts), helpers.NO_OVERWRITE
             ),
+            '.isort.cfg': (
+                isort_cfg(opts), helpers.NO_OVERWRITE
+            ),
         }
 
         return helpers.merge(struct, {opts['project']: files}), opts
@@ -54,9 +61,11 @@ class PreCommit(Extension):
             'project but in order to make sure the hooks will run, please '
             'don\'t forget to install the `pre-commit` package:\n\n'
             '  cd %s\n'
-            '  # you should consider creating/activating a virtualenv here\n'
+            '  # it is a good idea to create and activate a virtualenv here\n'
             '  pip install pre-commit\n'
-            '  pre-commit install\n\n'
+            '  pre-commit install\n'
+            '  # another good idea is update the hooks to the latest version\n'
+            '  # pre-commit autoupdate\n\n'
             'You might also consider including similar instructions in your '
             'docs, to remind the contributors to do the same.\n',
             opts['project'])

--- a/src/pyscaffold/extensions/pre_commit.py
+++ b/src/pyscaffold/extensions/pre_commit.py
@@ -6,9 +6,9 @@ Extension that generates configuration files for Yelp `pre-commit`_.
 """
 from __future__ import absolute_import
 
+from ..api import Extension, helpers
+from ..log import logger
 from ..templates import pre_commit_config
-from ..api import Extension
-from ..api import helpers
 
 
 class PreCommit(Extension):
@@ -22,12 +22,12 @@ class PreCommit(Extension):
         Returns:
             list: updated list of actions
         """
-        return self.register(
-            actions,
-            self.add_files,
-            after='define_structure')
+        return (
+            self.register(actions, self.add_files, after='define_structure') +
+            [self.instruct_user])
 
-    def add_files(self, struct, opts):
+    @staticmethod
+    def add_files(struct, opts):
         """Add .pre-commit-config.yaml file to structure
 
         Args:
@@ -46,3 +46,19 @@ class PreCommit(Extension):
         }
 
         return helpers.merge(struct, {opts['project']: files}), opts
+
+    @staticmethod
+    def instruct_user(struct, opts):
+        logger.warning(
+            '\nA `.pre-commit-config.yaml` file was generated inside your '
+            'project but in order to make sure the hooks will run, please '
+            'don\'t forget to install the `pre-commit` package:\n\n'
+            '  cd %s\n'
+            '  # you should consider creating/activating a virtualenv here\n'
+            '  pip install pre-commit\n'
+            '  pre-commit install\n\n'
+            'You might also consider including similar instructions in your '
+            'docs, to remind the contributors to do the same.\n',
+            opts['project'])
+
+        return struct, opts

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -349,6 +349,19 @@ def pre_commit_config(opts):
     return template.safe_substitute(opts)
 
 
+def isort_cfg(opts):
+    """Template of .isort.cfg
+
+    Args:
+        opts: mapping parameters as dictionary
+
+    Returns:
+        str: file content as string
+    """
+    template = get_template("isort_cfg")
+    return template.safe_substitute(opts)
+
+
 def namespace(opts):
     """Template of __init__.py defining a namespace package
 

--- a/src/pyscaffold/templates/gitignore.template
+++ b/src/pyscaffold/templates/gitignore.template
@@ -3,6 +3,7 @@
 *.py[cod]
 *.so
 *.cfg
+!.isort.cfg
 !setup.cfg
 *.orig
 *.log
@@ -40,3 +41,6 @@ docs/api/*
 docs/_build/*
 cover/*
 MANIFEST
+
+# Per-project virtualenvs
+.venv*/

--- a/src/pyscaffold/templates/isort_cfg.template
+++ b/src/pyscaffold/templates/isort_cfg.template
@@ -1,11 +1,11 @@
 [settings]
 line_length=79
 indent='    '
-skip=src/pyscaffold/contrib,.tox,.venv,build,dist
-known_standard_library=StringIO,__builtin__,setuptools,pkg_resources
+skip=.tox,.venv,build,dist
+known_standard_library=setuptools,pkg_resources
 known_compat=six
 known_test=pytest
-known_first_party=pyscaffold
+known_first_party=${root_pkg}
 sections=FUTURE,STDLIB,COMPAT,TEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 default_section=THIRDPARTY
 multi_line_output=3

--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -1,20 +1,27 @@
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v0.8.0
+    sha: v1.3.0
     hooks:
     -   id: trailing-whitespace
-    -   id: check-ast
     -   id: check-added-large-files
+    -   id: check-ast
     -   id: check-json
-    -   id: check-yaml
+    -   id: check-merge-conflict
     -   id: check-xml
+    -   id: check-yaml
     -   id: debug-statements
     -   id: end-of-file-fixer
     -   id: requirements-txt-fixer
+    -   id: mixed-line-ending
+        args:
+        - --fix=no
     -   id: flake8
-        args: ["--exclude=docs/conf.py"]
-
--   repo: git://github.com/FalconSocial/pre-commit-python-sorter
-    sha: 1.0.4
+        args:
+        - --exclude=docs/conf.py
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v1.0.0
     hooks:
-    -   id: python-import-sorter
-        args: ['--silent-overwrite']
+    -   id: seed-isort-config
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.4
+    hooks:
+    -   id: isort

--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -17,10 +17,6 @@
     -   id: flake8
         args:
         - --exclude=docs/conf.py
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v1.0.0
-    hooks:
-    -   id: seed-isort-config
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.4
     hooks:

--- a/tests/extensions/test_pre_commit.py
+++ b/tests/extensions/test_pre_commit.py
@@ -18,6 +18,7 @@ def test_create_project_with_pre_commit(tmpfolder, caplog):
 
     # then pre-commit files should exist
     assert path_exists("proj/.pre-commit-config.yaml")
+    assert path_exists("proj/.isort.cfg")
 
     # and the user should be instructed to install pre-commit
     expected_warnings = ('to make sure the hooks will run',
@@ -37,6 +38,7 @@ def test_create_project_without_pre_commit(tmpfolder):
 
     # then pre-commit files should not exist
     assert not path_exists("proj/.pre-commit-config.yaml")
+    assert not path_exists("proj/.isort.cfg")
 
 
 def test_cli_with_pre_commit(tmpfolder):
@@ -48,6 +50,7 @@ def test_cli_with_pre_commit(tmpfolder):
 
     # then pre-commit files should exist
     assert path_exists("proj/.pre-commit-config.yaml")
+    assert path_exists("proj/.isort.cfg")
 
 
 def test_cli_without_pre_commit(tmpfolder):
@@ -59,3 +62,4 @@ def test_cli_without_pre_commit(tmpfolder):
 
     # then pre-commit files should not exist
     assert not path_exists("proj/.pre-commit-config.yaml")
+    assert not path_exists("proj/.isort.cfg")

--- a/tests/extensions/test_pre_commit.py
+++ b/tests/extensions/test_pre_commit.py
@@ -8,7 +8,7 @@ from pyscaffold.cli import run
 from pyscaffold.extensions import pre_commit
 
 
-def test_create_project_with_pre_commit(tmpfolder):
+def test_create_project_with_pre_commit(tmpfolder, caplog):
     # Given options with the pre-commit extension,
     opts = dict(project="proj",
                 extensions=[pre_commit.PreCommit('pre-commit')])
@@ -18,6 +18,14 @@ def test_create_project_with_pre_commit(tmpfolder):
 
     # then pre-commit files should exist
     assert path_exists("proj/.pre-commit-config.yaml")
+
+    # and the user should be instructed to install pre-commit
+    expected_warnings = ('to make sure the hooks will run',
+                         'cd proj',
+                         'pre-commit install')
+    log = caplog.text
+    for text in expected_warnings:
+        assert text in log
 
 
 def test_create_project_without_pre_commit(tmpfolder):


### PR DESCRIPTION
Due to changes in the new versions released for the `pre-commit` package since the `pre-commit-config.yaml` file was written, some of the hooks were broken.

This PR is an attempt to have working and better hooks for PyScaffold. Additionally, similar configurations are introduced in the templates for the `pre-commit` extension.

A new .isort.cfg template is also introduced to facilitate using the `isort` hook included by default in the pre-commit configuration template.