### PR TITLE
Make `test_install` isolated by running everything inside separated virtualenvs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - tox
   - ./tests/system_test.sh
 after_success:
-  - if [[ "$COVERAGE" == "true" ]]; then py.test tests; coveralls || echo "failed"; fi
+  - if [[ "$COVERAGE" == "true" ]]; then tox; coveralls || echo "failed"; fi
 cache:
   apt: true
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
   - tox
   - ./tests/system_test.sh
 after_success:
-  - if [[ "$COVERAGE" == "true" ]]; then tox; coveralls || echo "failed"; fi
+  - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi
 cache:
   apt: true
   pip: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 package_dir =
     =src
 install_requires = setuptools>=30.3.0
-tests_require = pytest; pytest-cov
+tests_require = pytest; pytest-cov; pytest-xdist
 
 [options.packages.find]
 where = src
@@ -55,6 +55,7 @@ addopts = tests --verbose
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
     -p coverage
+    --dist=load --numprocesses=auto
     --cov pyscaffold --cov-report term-missing
     --verbose
 norecursedirs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 package_dir =
     =src
 install_requires = setuptools>=30.3.0
-tests_require = pytest; pytest-cov; pytest-xdist; pytest-virtualenv
+tests_require = pytest; pytest-cov; pytest-virtualenv
 
 [options.packages.find]
 where = src
@@ -55,7 +55,6 @@ addopts = --verbose
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
     -p coverage
-    --dist=load --numprocesses=auto
     --cov pyscaffold --cov-report term-missing
     --verbose
 norecursedirs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 package_dir =
     =src
 install_requires = setuptools>=30.3.0
-tests_require = pytest; pytest-cov; pytest-xdist
+tests_require = pytest; pytest-cov; pytest-xdist; pytest-virtualenv
 
 [options.packages.find]
 where = src
@@ -46,7 +46,7 @@ all = django; cookiecutter
 
 [test]
 # py.test options when running `python setup.py test`
-addopts = tests --verbose
+addopts = --verbose
 
 [tool:pytest]
 # Options for py.test:
@@ -62,6 +62,7 @@ norecursedirs =
     dist
     build
     .tox
+testpaths = tests
 
 [aliases]
 release = sdist bdist_wheel upload

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import sys
 from contextlib import contextmanager
+from glob import glob
 from os.path import join as path_join
 from os.path import exists
 from shutil import copyfile, rmtree
@@ -25,139 +26,176 @@ import pytest
 
 from pyscaffold import shell
 from pyscaffold.cli import main as putup
-from pyscaffold.repo import add_tag
 from pyscaffold.shell import command_exists, git
 from pyscaffold.utils import chdir
 
-pytestmark = pytest.mark.slow
 
-__location__ = os.path.join(os.getcwd(), os.path.dirname(
+__location__ = path_join(os.getcwd(), os.path.dirname(
     inspect.getfile(inspect.currentframe())))
 
 
-def cmd_path(cmd):
-    """Try to get a fully specified command path.
-
-    Returns the full path when possible, otherwise just the command name.
-    Useful when running from virtualenv context.
-    """
-    candidates = os.getenv('PATH', '').split(os.pathsep)
-    candidates.insert(0, path_join(sys.prefix, 'bin'))
-
-    if hasattr(sys, 'real_prefix'):
-        candidates.insert(1, path_join(getattr(sys, 'real_prefix'), 'bin'))
-
-    for candidate in candidates:
-        full_path = path_join(candidate, cmd)
-        if exists(full_path):
-            return full_path
-
-    return cmd
+pytestmark = pytest.mark.slow
 
 
-def venv_cmd(cmd, *args):
-    """Create a callable from a command inside a virtualenv."""
-    return shell.ShellCommand(' '.join([cmd_path(cmd)] + list(args)))
-
-
-pip = venv_cmd("pip")
-setup_py = venv_cmd("python", "setup.py")
 untar = shell.ShellCommand(
-    ("gtar" if command_exists("gtar") else "tar") + " xvzkf")
-type_ = shell.ShellCommand('file')
+            ("gtar" if command_exists("gtar") else "tar") + " xvzkf")
 # ^ BSD tar differs in options from GNU tar,
 #   so make sure to use the correct one...
 #   https://xkcd.com/1168/
 
 
-def is_inside_venv():
-    return hasattr(sys, 'real_prefix')
+@pytest.fixture
+def venv(virtualenv):
+    return virtualenv
 
 
-def check_clean_venv():
-    installed = [line.split()[0] for line in pip('list')]
-    dirty = ['demoapp', 'demoapp_data', 'UNKNOWN']
-    app_list = [x for x in dirty if x in installed]
-    if not app_list:
-        return
-    else:
-        raise RuntimeError("Dirty virtual environment:\n{} found".format(
-            ', '.join(app_list)))
+@pytest.fixture
+def demoapp(tmpfolder, venv):
+    return DemoApp(tmpfolder, venv)
 
 
-def create_demoapp(data=False):
-    if data:
-        demoapp = 'demoapp_data'
-    else:
-        demoapp = 'demoapp'
+@pytest.fixture
+def demoapp_data(tmpfolder, venv):
+    return DemoApp(tmpfolder, venv, data=True)
 
-    putup([demoapp])
-    with chdir(demoapp):
-        demoapp_src_dir = os.path.join(__location__, demoapp)
-        demoapp_dst_root = os.getcwd()
-        demoapp_dst_pkg = os.path.join(demoapp_dst_root, 'src', demoapp)
-        copyfile(os.path.join(demoapp_src_dir, 'runner.py'),
-                 os.path.join(demoapp_dst_pkg, 'runner.py'))
-        git('add', os.path.join(demoapp_dst_pkg, 'runner.py'))
-        copyfile(os.path.join(demoapp_src_dir, 'setup.cfg'),
-                 os.path.join(demoapp_dst_root, 'setup.cfg'))
-        copyfile(os.path.join(demoapp_src_dir, 'setup.py'),
-                 os.path.join(demoapp_dst_root, 'setup.py'))
-        git('add', os.path.join(demoapp_dst_root, 'setup.cfg'))
-        git('add', os.path.join(demoapp_dst_root, 'setup.py'))
+
+class DemoApp(object):
+    def __init__(self, tmpdir, venv, data=None):
+        self.name = 'demoapp'
         if data:
-            data_src_dir = os.path.join(demoapp_src_dir, 'data')
-            data_dst_dir = os.path.join(demoapp_dst_pkg, 'data')
-            os.mkdir(data_dst_dir)
-            copyfile(os.path.join(data_src_dir, 'hello_world.txt'),
-                     os.path.join(data_dst_dir, 'hello_world.txt'))
-            git('add', os.path.join(data_dst_dir, 'hello_world.txt'))
-        git('commit', '-m', 'Added basic application logic')
+            self.name += '_data'
+        self.pkg_path = path_join(str(tmpdir), self.name)
+        self.built = False
+        self.installed = False
+        self.venv = venv
+        self.venv_path = str(venv.virtualenv)
+        self.data = data
+        self.dist = None
+
+        with chdir(str(tmpdir)):
+            self._generate()
+
+    def _generate(self):
+        putup([self.name])
+        with chdir(self.name):
+            demoapp_src_dir = path_join(__location__, self.name)
+            demoapp_dst_root = self.pkg_path
+            demoapp_dst_pkg = path_join(demoapp_dst_root, 'src', self.name)
+            copyfile(path_join(demoapp_src_dir, 'runner.py'),
+                     path_join(demoapp_dst_pkg, 'runner.py'))
+            git('add', path_join(demoapp_dst_pkg, 'runner.py'))
+            copyfile(path_join(demoapp_src_dir, 'setup.cfg'),
+                     path_join(demoapp_dst_root, 'setup.cfg'))
+            copyfile(path_join(demoapp_src_dir, 'setup.py'),
+                     path_join(demoapp_dst_root, 'setup.py'))
+            git('add', path_join(demoapp_dst_root, 'setup.cfg'))
+            git('add', path_join(demoapp_dst_root, 'setup.py'))
+            if self.data:
+                data_src_dir = path_join(demoapp_src_dir, 'data')
+                data_dst_dir = path_join(demoapp_dst_pkg, 'data')
+                os.mkdir(data_dst_dir)
+                copyfile(path_join(data_src_dir, 'hello_world.txt'),
+                         path_join(data_dst_dir, 'hello_world.txt'))
+                git('add', path_join(data_dst_dir, 'hello_world.txt'))
+            git('commit', '-m', 'Added basic application logic')
+
+    def check_not_installed(self):
+        installed = [line.split()[0]
+                     for line in self.run('pip', 'list').split('\n')[2:]]
+        dirty = [self.name, 'UNKNOWN']
+        app_list = [x for x in dirty if x in installed]
+        if app_list:
+            raise RuntimeError('Dirty virtual environment:\n%s found',
+                               ', '.join(app_list))
+
+    def check_inside_venv(self):
+        cmd_path = self.run('which', self.name)
+        if self.venv_path not in cmd_path:
+            raise RuntimeError('%s should be installed inside the venv (%s), '
+                               'but path is %s.',
+                               self.name, self.venv_path, cmd_path)
+
+    @contextmanager
+    def guard(self, attr):
+        if getattr(self, attr):
+            raise RuntimeError(
+                'For simplicity, just build/install once per package')
+        yield
+        setattr(self, attr, True)
+
+    def run(self, *args, **kwargs):
+        # pytest-virtualenv doesn't play nicely with external os.chdir
+        # so let's be explicity about it...
+        kwargs['cd'] = os.getcwd()
+        kwargs['capture'] = True
+        return self.venv.run(args, **kwargs).strip()
+
+    def cli(self, *args, **kwargs):
+        self.check_inside_venv()
+        args = [self.name] + list(args)
+        return self.run(*args, **kwargs)
 
 
-def build_demoapp(dist, path=None, demoapp='demoapp'):
-    if path is None:
-        path = os.getcwd()
-    path = os.path.join(path, demoapp)
-    with chdir(path):
-        setup_py(dist)
+    def setup_py(self, *args, **kwargs):
+        with chdir(self.pkg_path):
+            args = ['python', 'setup.py'] + list(args)
+            return self.run(*args, **kwargs)
 
 
-@contextmanager
-def installed_demoapp(dist=None, path=None, demoapp='demoapp'):
-    check_clean_venv()
-    if path is None:
-        path = os.getcwd()
-    path = os.path.join(path, demoapp, "dist", "{}*".format(demoapp))
-    if dist == 'bdist':
+    def build(self, dist='bdist'):
+        with self.guard('built'), chdir(self.pkg_path):
+            if 'wheel' in dist:
+                self.run('pip', 'install', 'wheel')
+            self.run('python', 'setup.py', dist)
+        self.dist = dist
+        return self
+
+    @property
+    def dist_file(self):
+        return list(glob(path_join(self.pkg_path, "dist", self.name + "*")))[0]
+
+    def _install_bdist(self):
         with chdir('/'):
-            output = untar(path)
-        install_dirs = list()
-        install_bin = None
-        for line in output:
-            if re.search(r".*/site-packages/{}.*?/$".format(demoapp), line):
-                install_dirs.append(line)
-            if re.search(r".*/bin/{}$".format(demoapp), line):
-                install_bin = line
-    elif dist == 'install':
-        with chdir(demoapp):
-            setup_py('install')
-    else:
-        pip("install", path)
-    try:
-        yield venv_cmd(demoapp)
-    finally:
-        if dist == 'bdist':
-            with chdir('/'):
-                os.remove(install_bin)
-                for path in install_dirs:
-                    rmtree(path, ignore_errors=True)
-        else:
-            pip("uninstall", "-y", demoapp)
+            # Because of the way bdist works, the tar.gz will contain
+            # the whole path to the current venv, starting from the
+            # / directory ...
+            untar(self.dist_file)
+
+    def install(self, edit=False):
+        with self.guard('installed'), chdir(self.pkg_path):
+            self.check_not_installed()
+            if edit or self.dist is None:
+                self.run('pip', 'install', '-e', '.')
+            elif self.dist == 'bdist':
+                self._install_bdist()
+            else:
+                self.run('pip', 'install', self.dist_file)
+        return self
+
+    def make_dirty_tree(self):
+        dirty_file = path_join(self.pkg_path, 'src', self.name, 'runner.py')
+        with open(dirty_file, 'a') as fh:
+            fh.write("\n\ndirty_variable = 69\n")
+        return self
+
+    def make_commit(self):
+        with chdir(self.pkg_path):
+            git('commit', '-a', '-m', 'message')
+        return self
+
+    def rm_git_tree(self):
+        git_path = path_join(self.pkg_path, '.git')
+        shutil.rmtree(git_path)
+        return self
+
+    def tag(self, name, message):
+        with chdir(self.pkg_path):
+            git('tag', '-a', name, '-m', message)
+        return self
 
 
 def check_version(output, exp_version, dirty=False):
-    version = output.split(' ')[-1]
+    version = output.strip().split(' ')[-1]
     # for some setuptools version a directory with + is generated, sometimes _
     if dirty:
         if '+' in version:
@@ -176,161 +214,173 @@ def check_version(output, exp_version, dirty=False):
         assert ver[0] == exp_version
 
 
-def make_dirty_tree(demoapp='demoapp'):
-    dirty_file = os.path.join('src', demoapp, 'runner.py')
-    with chdir(demoapp):
-        with open(dirty_file, 'a') as fh:
-            fh.write("\n\ndirty_variable = 69\n")
+def test_sdist_install(demoapp):
+    (demoapp
+        .build('sdist')
+        .install()
+    )
+    out = demoapp.cli('--version')
+    exp = "0.0.post0.dev2"
+    check_version(out, exp, dirty=False)
 
 
-def make_commit(demoapp='demoapp'):
-    with chdir(demoapp):
-        git('commit', '-a', '-m', 'message')
+def test_sdist_install_dirty(demoapp):
+    (demoapp
+        .tag('v0.1', 'first release')
+        .make_dirty_tree()
+        .make_commit()
+        .make_dirty_tree()
+        .build('sdist')
+        .install()
+    )
+    out = demoapp.cli('--version')
+    exp = "0.1.post0.dev1"
+    check_version(out, exp, dirty=True)
 
 
-def rm_git_tree(demoapp='demoapp'):
-    git_path = os.path.join(demoapp, '.git')
-    shutil.rmtree(git_path)
+def test_sdist_install_with_1_0_tag(demoapp):
+    (demoapp
+        .make_dirty_tree()
+        .make_commit()
+        .tag('v1.0', 'final release')
+        .build('sdist')
+        .install()
+    )
+    out = demoapp.cli('--version')
+    exp = "1.0"
+    check_version(out, exp, dirty=False)
 
 
-def test_sdist_install(tmpfolder):
-    create_demoapp()
-    build_demoapp('sdist')
-    with installed_demoapp() as demoapp:
-        out = next(demoapp('--version'))
-        exp = "0.0.post0.dev2"
-        check_version(out, exp, dirty=False)
-
-
-def test_sdist_install_dirty(tmpfolder):
-    create_demoapp()
-    add_tag('demoapp', 'v0.1', 'first tag')
-    make_dirty_tree()
-    make_commit()
-    make_dirty_tree()
-    build_demoapp('sdist')
-    with installed_demoapp() as demoapp:
-        out = next(demoapp('--version'))
-        exp = "0.1.post0.dev1"
-        check_version(out, exp, dirty=True)
-
-
-def test_sdist_install_with_1_0_tag(tmpfolder):
-    create_demoapp()
-    make_dirty_tree()
-    make_commit()
-    add_tag('demoapp', 'v1.0', 'final release')
-    build_demoapp('sdist')
-    with installed_demoapp() as demoapp:
-        out = next(demoapp('--version'))
-        exp = "1.0"
-        check_version(out, exp, dirty=False)
-
-
-def test_sdist_install_with_1_0_tag_dirty(tmpfolder):
-    create_demoapp()
-    add_tag('demoapp', 'v1.0', 'final release')
-    make_dirty_tree()
-    build_demoapp('sdist')
-    with installed_demoapp() as demoapp:
-        out = next(demoapp('--version'))
-        exp = "1.0"
-        check_version(out, exp, dirty=True)
+def test_sdist_install_with_1_0_tag_dirty(demoapp):
+    (demoapp
+        .tag('v1.0', 'final release')
+        .make_dirty_tree()
+        .build('sdist')
+        .install()
+    )
+    out = demoapp.cli('--version')
+    exp = "1.0"
+    check_version(out, exp, dirty=True)
 
 
 # bdist works like sdist so we only try one combination
-def test_bdist_install(tmpfolder):
-    create_demoapp()
-    build_demoapp('bdist')
-    with installed_demoapp('bdist') as demoapp:
-        out = next(demoapp('--version'))
-        exp = "0.0.post0.dev2"
-        check_version(out, exp, dirty=False)
+@pytest.mark.only
+def test_bdist_install(demoapp):
+    (demoapp
+        .build('bdist')
+        .install()
+    )
+    out = demoapp.cli('--version')
+    exp = "0.0.post0.dev2"
+    check_version(out, exp, dirty=False)
 
 
 # bdist wheel works like sdist so we only try one combination
-@pytest.mark.skipif(not is_inside_venv(),
-                    reason='Needs to run in a virtualenv')
-def test_bdist_wheel_install(tmpfolder):
-    create_demoapp()
-    build_demoapp('bdist_wheel')
-    with installed_demoapp() as demoapp:
-        out = next(demoapp('--version'))
-        exp = "0.0.post0.dev2"
-        check_version(out, exp, dirty=False)
+def test_bdist_wheel_install(demoapp):
+    (demoapp
+        .build('bdist_wheel')
+        .install()
+    )
+    out = demoapp.cli('--version')
+    exp = "0.0.post0.dev2"
 
 
-def test_git_repo(tmpfolder):
-    create_demoapp()
-    with installed_demoapp('install'), chdir('demoapp'):
-        out = next(setup_py('--version'))
-        exp = '0.0.post0.dev2'
-        check_version(out, exp, dirty=False)
+def test_git_repo(demoapp):
+    out = demoapp.setup_py('--version')
+    exp = '0.0.post0.dev2'
+    check_version(out, exp, dirty=False)
 
 
-def test_git_repo_dirty(tmpfolder):
-    create_demoapp()
-    add_tag('demoapp', 'v0.1', 'first tag')
-    make_dirty_tree()
-    make_commit()
-    make_dirty_tree()
-    with installed_demoapp('install'), chdir('demoapp'):
-        out = next(setup_py('--version'))
-        exp = '0.1.post0.dev1'
-        check_version(out, exp, dirty=True)
+def test_git_repo_dirty(demoapp):
+    (demoapp
+        .tag('v0.1', 'first release')
+        .make_dirty_tree()
+        .make_commit()
+        .make_dirty_tree()
+    )
+    out = demoapp.setup_py('--version')
+    exp = "0.1.post0.dev1"
+    check_version(out, exp, dirty=True)
 
 
-def test_git_repo_with_1_0_tag(tmpfolder):
-    create_demoapp()
-    add_tag('demoapp', 'v1.0', 'final release')
-    with installed_demoapp('install'), chdir('demoapp'):
-        out = next(setup_py('--version'))
-        exp = '1.0'
-        check_version(out, exp, dirty=False)
+def test_git_repo_with_1_0_tag(demoapp):
+    (demoapp
+        .tag('v1.0', 'final release')
+    )
+    out = demoapp.setup_py('--version')
+    exp = "1.0"
+    check_version(out, exp, dirty=False)
 
 
-def test_git_repo_with_1_0_tag_dirty(tmpfolder):
-    create_demoapp()
-    add_tag('demoapp', 'v1.0', 'final release')
-    make_dirty_tree()
-    with installed_demoapp('install'), chdir('demoapp'):
-        out = next(setup_py('--version'))
-        exp = '1.0'
-        check_version(out, exp, dirty=True)
+
+def test_git_repo_with_1_0_tag_dirty(demoapp):
+    (demoapp
+        .tag('v1.0', 'final release')
+        .make_dirty_tree()
+    )
+    out = demoapp.setup_py('--version')
+    exp = "1.0"
+    check_version(out, exp, dirty=True)
 
 
-def test_sdist_install_with_data(tmpfolder):
-    create_demoapp(data=True)
-    build_demoapp('sdist', demoapp='demoapp_data')
-    with installed_demoapp(demoapp='demoapp_data') as demoapp_data:
-        out = next(demoapp_data())
-        exp = "Hello World"
-        assert out.startswith(exp)
+def test_sdist_install_with_data(demoapp_data):
+    (demoapp_data
+        .build('sdist')
+        .install()
+    )
+    out = demoapp_data.cli()
+    exp = "Hello World"
+    assert out.startswith(exp)
 
 
-def test_bdist_install_with_data(tmpfolder):
-    create_demoapp(data=True)
-    build_demoapp('bdist', demoapp='demoapp_data')
-    with installed_demoapp('bdist', demoapp='demoapp_data') as demoapp_data:
-        out = next(demoapp_data())
-        exp = "Hello World"
-        assert out.startswith(exp)
+def test_bdist_install_with_data(demoapp_data):
+    (demoapp_data
+        .build('bdist')
+        .install()
+    )
+    out = demoapp_data.cli()
+    exp = "Hello World"
+    assert out.startswith(exp)
 
 
-@pytest.mark.skipif(not is_inside_venv(),
-                    reason='Needs to run in a virtualenv')
-def test_bdist_wheel_install_with_data(tmpfolder):
-    create_demoapp(data=True)
-    build_demoapp('bdist_wheel', demoapp='demoapp_data')
-    with installed_demoapp(demoapp='demoapp_data') as demoapp_data:
-        out = next(demoapp_data())
-        exp = "Hello World"
-        assert out.startswith(exp)
+def test_bdist_wheel_install_with_data(demoapp_data):
+    (demoapp_data
+        .build('bdist_wheel')
+        .install()
+    )
+    out = demoapp_data.cli()
+    exp = "Hello World"
+    assert out.startswith(exp)
 
 
-def test_setup_py_install(tmpfolder):
-    create_demoapp()
-    with installed_demoapp('install', demoapp='demoapp') as demoapp:
-        out = next(demoapp('--version'))
-        exp = "0.0.post0.dev2"
-        check_version(out, exp, dirty=False)
+def test_edit_install_with_data(demoapp_data):
+    (demoapp_data
+        .install(edit=True)
+    )
+    out = demoapp_data.cli()
+    exp = "Hello World"
+    assert out.startswith(exp)
+
+
+def test_setup_py_install_with_data(demoapp_data):
+    (demoapp_data
+        .setup_py('install')
+    )
+    out = demoapp_data.cli()
+    exp = "Hello World"
+    assert out.startswith(exp)
+    out = demoapp_data.cli('--version')
+    exp = "0.0.post0.dev2"
+    check_version(out, exp, dirty=False)
+
+
+def test_setup_py_develop_with_data(demoapp_data):
+    (demoapp_data
+        .setup_py('develop')
+    )
+    out = demoapp_data.cli()
+    exp = "Hello World"
+    assert out.startswith(exp)
+    out = demoapp_data.cli('--version')
+    exp = "0.0.post0.dev2"
+    check_version(out, exp, dirty=False)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -13,14 +13,11 @@ from __future__ import absolute_import, division, print_function
 
 import inspect
 import os
-import re
 import shutil
-import sys
 from contextlib import contextmanager
 from glob import glob
 from os.path import join as path_join
-from os.path import exists
-from shutil import copyfile, rmtree
+from shutil import copyfile
 
 import pytest
 
@@ -135,12 +132,10 @@ class DemoApp(object):
         args = [self.name] + list(args)
         return self.run(*args, **kwargs)
 
-
     def setup_py(self, *args, **kwargs):
         with chdir(self.pkg_path):
             args = ['python', 'setup.py'] + list(args)
             return self.run(*args, **kwargs)
-
 
     def build(self, dist='bdist'):
         with self.guard('built'), chdir(self.pkg_path):
@@ -217,8 +212,7 @@ def check_version(output, exp_version, dirty=False):
 def test_sdist_install(demoapp):
     (demoapp
         .build('sdist')
-        .install()
-    )
+        .install())
     out = demoapp.cli('--version')
     exp = "0.0.post0.dev2"
     check_version(out, exp, dirty=False)
@@ -231,8 +225,7 @@ def test_sdist_install_dirty(demoapp):
         .make_commit()
         .make_dirty_tree()
         .build('sdist')
-        .install()
-    )
+        .install())
     out = demoapp.cli('--version')
     exp = "0.1.post0.dev1"
     check_version(out, exp, dirty=True)
@@ -244,8 +237,7 @@ def test_sdist_install_with_1_0_tag(demoapp):
         .make_commit()
         .tag('v1.0', 'final release')
         .build('sdist')
-        .install()
-    )
+        .install())
     out = demoapp.cli('--version')
     exp = "1.0"
     check_version(out, exp, dirty=False)
@@ -256,8 +248,7 @@ def test_sdist_install_with_1_0_tag_dirty(demoapp):
         .tag('v1.0', 'final release')
         .make_dirty_tree()
         .build('sdist')
-        .install()
-    )
+        .install())
     out = demoapp.cli('--version')
     exp = "1.0"
     check_version(out, exp, dirty=True)
@@ -268,8 +259,7 @@ def test_sdist_install_with_1_0_tag_dirty(demoapp):
 def test_bdist_install(demoapp):
     (demoapp
         .build('bdist')
-        .install()
-    )
+        .install())
     out = demoapp.cli('--version')
     exp = "0.0.post0.dev2"
     check_version(out, exp, dirty=False)
@@ -279,10 +269,10 @@ def test_bdist_install(demoapp):
 def test_bdist_wheel_install(demoapp):
     (demoapp
         .build('bdist_wheel')
-        .install()
-    )
+        .install())
     out = demoapp.cli('--version')
     exp = "0.0.post0.dev2"
+    check_version(out, exp, dirty=False)
 
 
 def test_git_repo(demoapp):
@@ -296,28 +286,23 @@ def test_git_repo_dirty(demoapp):
         .tag('v0.1', 'first release')
         .make_dirty_tree()
         .make_commit()
-        .make_dirty_tree()
-    )
+        .make_dirty_tree())
     out = demoapp.setup_py('--version')
     exp = "0.1.post0.dev1"
     check_version(out, exp, dirty=True)
 
 
 def test_git_repo_with_1_0_tag(demoapp):
-    (demoapp
-        .tag('v1.0', 'final release')
-    )
+    demoapp.tag('v1.0', 'final release')
     out = demoapp.setup_py('--version')
     exp = "1.0"
     check_version(out, exp, dirty=False)
 
 
-
 def test_git_repo_with_1_0_tag_dirty(demoapp):
     (demoapp
         .tag('v1.0', 'final release')
-        .make_dirty_tree()
-    )
+        .make_dirty_tree())
     out = demoapp.setup_py('--version')
     exp = "1.0"
     check_version(out, exp, dirty=True)
@@ -326,8 +311,7 @@ def test_git_repo_with_1_0_tag_dirty(demoapp):
 def test_sdist_install_with_data(demoapp_data):
     (demoapp_data
         .build('sdist')
-        .install()
-    )
+        .install())
     out = demoapp_data.cli()
     exp = "Hello World"
     assert out.startswith(exp)
@@ -336,8 +320,7 @@ def test_sdist_install_with_data(demoapp_data):
 def test_bdist_install_with_data(demoapp_data):
     (demoapp_data
         .build('bdist')
-        .install()
-    )
+        .install())
     out = demoapp_data.cli()
     exp = "Hello World"
     assert out.startswith(exp)
@@ -346,26 +329,21 @@ def test_bdist_install_with_data(demoapp_data):
 def test_bdist_wheel_install_with_data(demoapp_data):
     (demoapp_data
         .build('bdist_wheel')
-        .install()
-    )
+        .install())
     out = demoapp_data.cli()
     exp = "Hello World"
     assert out.startswith(exp)
 
 
 def test_edit_install_with_data(demoapp_data):
-    (demoapp_data
-        .install(edit=True)
-    )
+    demoapp_data.install(edit=True)
     out = demoapp_data.cli()
     exp = "Hello World"
     assert out.startswith(exp)
 
 
 def test_setup_py_install_with_data(demoapp_data):
-    (demoapp_data
-        .setup_py('install')
-    )
+    demoapp_data.setup_py('install')
     out = demoapp_data.cli()
     exp = "Hello World"
     assert out.startswith(exp)
@@ -375,9 +353,7 @@ def test_setup_py_install_with_data(demoapp_data):
 
 
 def test_setup_py_develop_with_data(demoapp_data):
-    (demoapp_data
-        .setup_py('develop')
-    )
+    demoapp_data.setup_py('develop')
     out = demoapp_data.cli()
     exp = "Hello World"
     assert out.startswith(exp)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,6 +7,10 @@ There are four tree states we want to check:
  B: dirtying the tree after 1.0
  C: a commit after a tag, clean tree
  D: a commit after a tag, dirty tree
+
+The tests written in this file use pytest-virtualenv to achieve isolation.
+Each test will run inside a different venv in a temporary directory, so they
+can execute in parallel and not interfere with each other.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -255,7 +259,6 @@ def test_sdist_install_with_1_0_tag_dirty(demoapp):
 
 
 # bdist works like sdist so we only try one combination
-@pytest.mark.only
 def test_bdist_install(demoapp):
     (demoapp
         .build('bdist')
@@ -265,7 +268,6 @@ def test_bdist_install(demoapp):
     check_version(out, exp, dirty=False)
 
 
-# bdist wheel works like sdist so we only try one combination
 def test_bdist_wheel_install(demoapp):
     (demoapp
         .build('bdist_wheel')

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,11 @@ minversion = 1.8
 passenv =
     HOME
 commands =
-    py.test tests {posargs}
+    py.test {posargs}
 deps =
     pytest
     pytest-cov
     pytest-xdist
     django
     cookiecutter
+    pytest-virtualenv

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ commands =
 deps =
     pytest
     pytest-cov
-    pytest-xdist
     django
     cookiecutter
     pytest-virtualenv

--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,6 @@ commands =
 deps =
     pytest
     pytest-cov
+    pytest-xdist
     django
     cookiecutter


### PR DESCRIPTION
This PR tries to solve #119 as effort to make the tests able to run in parallel.
(Althought I don't know if the extra trouble of creating multiple venvs is worth the gain in speed we can have).