### PR TITLE
Isolate logging in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_script:
 script:
   - pip list
   - python setup.py develop
-  - tox
+  - tox -- -n 15
   - ./tests/system_test.sh
 after_success:
   - if [[ "$COVERAGE" == "true" ]]; then coveralls || echo "failed"; fi

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -87,6 +87,18 @@ Clone the repository
    `tox`_ with ``pip install tox``.
    Don't forget to also add unit tests in case your contribution
    adds an additional feature and is not just a bugfix.
+
+   To speed up running the tests, you can try to run them in parallel, using
+   ``pytest-xdist``. This plugin is already added to the test dependencies, so
+   everything you need to do is adding ``-n auto`` or
+   ``-n <NUMBER OF PROCESS>`` in the CLI. For example::
+
+    tox -- -n 15
+
+   Please have in mind that PyScaffold test suite is IO intensive, so using a
+   number of processes slightly bigger than the available number of CPUs is a
+   good idea.
+
 #. Use `flake8`_ to check your code style.
 #. Add yourself to the list of contributors in ``AUTHORS.rst``.
 #. Go to the web page of your PyScaffold fork, and click

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ addopts = --verbose
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
     -p coverage
-    --dist=load --numprocesses=20
+    --dist=load --numprocesses=auto
     --cov pyscaffold --cov-report term-missing
     --verbose
 norecursedirs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ include_package_data = True
 package_dir =
     =src
 install_requires = setuptools>=30.3.0
-tests_require = pytest; pytest-cov; pytest-virtualenv
+tests_require = pytest; pytest-cov; pytest-virtualenv; pytest-xdist
 
 [options.packages.find]
 where = src
@@ -55,6 +55,7 @@ addopts = --verbose
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
     -p coverage
+    --dist=load --numprocesses=auto
     --cov pyscaffold --cov-report term-missing
     --verbose
 norecursedirs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,9 @@ package_dir =
     =src
 install_requires = setuptools>=30.3.0
 tests_require = pytest; pytest-cov; pytest-virtualenv; pytest-xdist
+# We keep pytest-xdist in the test dependencies, so the developer can easily
+# opt-in for distributed tests by adding, for example, the `-n 15` arguments in
+# the command-line.
 
 [options.packages.find]
 where = src
@@ -54,10 +57,11 @@ addopts = --verbose
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
-    -p coverage
-    --dist=load --numprocesses=auto
     --cov pyscaffold --cov-report term-missing
     --verbose
+#    In order to use xdist, the developer can add, for example, the following
+#    arguments:
+#    --dist=load --numprocesses=auto
 norecursedirs =
     dist
     build

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ addopts = --verbose
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
     -p coverage
-    --dist=load --numprocesses=auto
+    --dist=load --numprocesses=20
     --cov pyscaffold --cov-report term-missing
     --verbose
 norecursedirs =

--- a/src/pyscaffold/log.py
+++ b/src/pyscaffold/log.py
@@ -279,6 +279,9 @@ class ReportLogger(LoggerAdapter):
                 # --------------------------------------
                 # Note how the spacing between activity and subject in the
                 # second entry is greater than the equivalent in the first one.
+
+        Note:
+            This method is not thread-safe and should be used with care.
         """
         prev = self.nesting
         self.nesting += count

--- a/src/pyscaffold/log.py
+++ b/src/pyscaffold/log.py
@@ -29,7 +29,7 @@ def configure_logger(opts):
         opts (dict): command line parameters
     """
     if 'log_level' in opts:
-        getLogger(DEFAULT_LOGGER).setLevel(opts['log_level'])
+        logger.level = opts['log_level']
 
     # if terminal supports, use colors
     stream = getattr(logger.handler, 'stream', None)
@@ -202,6 +202,16 @@ class ReportLogger(LoggerAdapter):
         self.handler.setFormatter(self.formatter)
         self.wrapped.addHandler(self.handler)
         super(ReportLogger, self).__init__(self.wrapped, self.extra)
+
+    @property
+    def level(self):
+        """Effective level of the logger"""
+        return self.wrapped.getEffectiveLevel()
+
+    @level.setter
+    def level(self, value):
+        """Set the logger level"""
+        self.wrapped.setLevel(value)
 
     def process(self, msg, kwargs):
         """Method overridden to augment LogRecord with the `nesting` attribute.

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -13,15 +13,15 @@ import sys
 from contextlib import contextmanager
 from operator import itemgetter
 
+from .contrib.setuptools_scm.version import VERSION_CLASS
+from .contrib.six import PY2
 from .exceptions import InvalidIdentifier, OldSetuptools
 from .log import logger
 from .templates import licenses
-from .contrib.six import PY2
-from .contrib.setuptools_scm.version import VERSION_CLASS
 
 
 @contextmanager
-def _chdir_logginng_context(path, should_log):
+def _chdir_logging_context(path, should_log):
     """Private auxiliar function for logging inside chdir"""
     if should_log:
         logger.report('chdir', path)
@@ -51,7 +51,7 @@ def chdir(path, **kwargs):
     curr_dir = os.getcwd()
 
     try:
-        with _chdir_logginng_context(path, should_log):
+        with _chdir_logging_context(path, should_log):
             if not should_pretend:
                 os.chdir(path)
             yield

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -21,6 +21,17 @@ from .contrib.setuptools_scm.version import VERSION_CLASS
 
 
 @contextmanager
+def _chdir_logginng_context(path, should_log):
+    """Private auxiliar function for logging inside chdir"""
+    if should_log:
+        logger.report('chdir', path)
+        with logger.indent():
+            yield
+    else:
+        yield
+
+
+@contextmanager
 def chdir(path, **kwargs):
     """Contextmanager to change into a directory
 
@@ -38,15 +49,11 @@ def chdir(path, **kwargs):
     #   (after all, this is the primary purpose of pretending)
 
     curr_dir = os.getcwd()
-    if not should_pretend:
-        os.chdir(path)
 
     try:
-        if should_log:
-            logger.report('chdir', path)
-            with logger.indent():
-                yield
-        else:
+        with _chdir_logginng_context(path, should_log):
+            if not should_pretend:
+                os.chdir(path)
             yield
     finally:
         os.chdir(curr_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,6 @@ from shutil import rmtree
 
 import pytest
 
-from pyscaffold.exceptions import ShellCommandException
-from pyscaffold.log import ReportFormatter
-
 from .helpers import uniqstr
 
 try:
@@ -43,6 +40,14 @@ def set_writable(func, path, exc_info):
         func(path)
     else:
         raise
+
+
+def command_exception(content):
+    # Be lazy to import modules, so coverage has time to setup all the
+    # required "probes"
+    # (see @FlorianWilhelm comments on #174)
+    from pyscaffold.exceptions import ShellCommandException
+    return ShellCommandException(content)
 
 
 @pytest.fixture
@@ -79,6 +84,10 @@ def isolated_logger(request, logger):
     old_formatter = logger.formatter
     old_wrapped = logger.wrapped
     old_nesting = logger.nesting
+
+    # Be lazy to import modules due to coverage warnings
+    # (see @FlorianWilhelm comments on #174)
+    from pyscaffold.log import ReportFormatter
 
     logger.wrapped = raw_logger
     logger.handler = new_handler
@@ -136,7 +145,7 @@ def git_mock(monkeypatch, logger):
 @pytest.fixture
 def nogit_mock(monkeypatch):
     def raise_error(*_):
-        raise ShellCommandException("No git mock!")
+        raise command_exception("No git mock!")
 
     monkeypatch.setattr('pyscaffold.shell.git', raise_error)
     yield
@@ -152,7 +161,7 @@ def nonegit_mock(monkeypatch):
 def noconfgit_mock(monkeypatch):
     def raise_error(*argv):
         if 'config' in argv:
-            raise ShellCommandException("No git mock!")
+            raise command_exception("No git mock!")
 
     monkeypatch.setattr('pyscaffold.shell.git', raise_error)
     yield
@@ -161,7 +170,7 @@ def noconfgit_mock(monkeypatch):
 @pytest.fixture
 def nodjango_admin_mock(monkeypatch):
     def raise_error(*_):
-        raise ShellCommandException("No django_admin mock!")
+        raise command_exception("No django_admin mock!")
 
     monkeypatch.setattr('pyscaffold.shell.django_admin', raise_error)
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,14 +11,12 @@ from os.path import isdir
 from shutil import rmtree
 from pkg_resources import DistributionNotFound
 
-from six import StringIO
-
 import pytest
 
 from pyscaffold.exceptions import ShellCommandException
-from pyscaffold.log import ReportFormatter, ReportLogger
+from pyscaffold.log import ReportFormatter
 
-from .log_helpers import random_time_based_string as uniqstr
+from .helpers import uniqstr
 
 try:
     # First try python 2.7.x
@@ -90,7 +88,7 @@ def isolated_logger(logger):
 
     logger.hanlder = old_handler
     logger.formatter = old_formatter
-    logger.wrapperd= old_wrapped
+    logger.wrapperd = old_wrapped
     logger.nesting = old_nesting
 
     new_handler.close()

--- a/tests/extensions/test_cookiecutter.py
+++ b/tests/extensions/test_cookiecutter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import logging
 import re
 import sys
 from os import environ
@@ -61,6 +62,7 @@ def test_create_project_with_cookiecutter(tmpfolder):
 
 def test_pretend_create_project_with_cookiecutter(tmpfolder, caplog):
     # Given options with the cookiecutter extension,
+    caplog.set_level(logging.INFO)
     opts = parse_args(
         [PROJ_NAME, '--pretend', '--cookiecutter', COOKIECUTTER_URL])
 
@@ -73,7 +75,8 @@ def test_pretend_create_project_with_cookiecutter(tmpfolder, caplog):
         assert not path_exists(path)
 
     # but activities should be logged
-    assert re.search(r'run\s+cookiecutter', caplog.text)
+    logs = caplog.text
+    assert re.search(r'run.+cookiecutter', logs)
 
 
 def test_create_project_with_cookiecutter_but_no_template(tmpfolder):

--- a/tests/extensions/test_django.py
+++ b/tests/extensions/test_django.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import logging
 import re
 import sys
 from os.path import exists as path_exists
@@ -38,6 +39,7 @@ def test_create_project_with_django(tmpfolder):
 @skip_py33
 def test_pretend_create_project_with_django(tmpfolder, caplog):
     # Given options with the django extension,
+    caplog.set_level(logging.INFO)
     opts = parse_args([PROJ_NAME, '--pretend', '--django'])
 
     # when the project is created,
@@ -49,7 +51,8 @@ def test_pretend_create_project_with_django(tmpfolder, caplog):
         assert not path_exists(path)
 
     # but activities should be logged
-    assert re.search(r'run\s+django', caplog.text)
+    logs = caplog.text
+    assert re.search(r'run.+django', logs)
 
 
 def test_create_project_without_django(tmpfolder):

--- a/tests/extensions/test_namespace.py
+++ b/tests/extensions/test_namespace.py
@@ -143,7 +143,7 @@ def test_move_old_package(tmpfolder):
     assert tmpfolder.join("proj/src/my/ns/my_pkg/__init__.py").check()
 
 
-def test_pretend_move_old_package(tmpfolder, caplog):
+def test_pretend_move_old_package(tmpfolder, caplog, isolated_logger):
     # Given a package is already created without namespace
     create_project(project="proj", package="my_pkg")
 

--- a/tests/extensions/test_pre_commit.py
+++ b/tests/extensions/test_pre_commit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import logging
 import sys
 from os.path import exists as path_exists
 
@@ -9,6 +10,7 @@ from pyscaffold.extensions import pre_commit
 
 
 def test_create_project_with_pre_commit(tmpfolder, caplog):
+    caplog.set_level(logging.WARNING)
     # Given options with the pre-commit extension,
     opts = dict(project="proj",
                 extensions=[pre_commit.PreCommit('pre-commit')])

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,25 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from random import choice
-from string import ascii_letters
-from time import time
-
-from six.moves import xrange
-
-
-def randstr(n=5):
-    """Generates a random string with n ascii_letters"""
-    return ''.join(choice(ascii_letters) for _ in xrange(n))
+from uuid import uuid4
 
 
 def uniqstr():
-    """Generates a random long string that contains random ascii_letters and
-    time-based parts.
-
-    The generated strings are meant to be unique, and then can be used to
-    identify log entries even if the stream is shared.
-    """
-    return ''.join(
-        randstr() + part
-        for part in str(time()).split('.')
-    )
+    """Generates a unique random long string every time it is called"""
+    return str(uuid4())

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from random import choice
+from string import ascii_letters
+from time import time
+
+from six.moves import xrange
+
+
+def randstr(n=5):
+    """Generates a random string with n ascii_letters"""
+    return ''.join(choice(ascii_letters) for _ in xrange(n))
+
+
+def uniqstr():
+    """Generates a random long string that contains random ascii_letters and
+    time-based parts.
+
+    The generated strings are meant to be unique, and then can be used to
+    identify log entries even if the stream is shared.
+    """
+    return ''.join(
+        randstr() + part
+        for part in str(time()).split('.')
+    )

--- a/tests/log_helpers.py
+++ b/tests/log_helpers.py
@@ -4,14 +4,6 @@ import logging
 import re
 
 
-def clear_log(log):
-    log.handler.records = []
-
-
-def last_log(log):
-    return log.records[-1].message
-
-
 def find_report(log, activity, subject):
     """Check if an activity was logged."""
     for record in log.records:

--- a/tests/log_helpers.py
+++ b/tests/log_helpers.py
@@ -2,12 +2,6 @@
 # -*- coding: utf-8 -*-
 import logging
 import re
-from collections import defaultdict
-from random import choice
-from string import ascii_letters
-from time import time
-
-from six.moves import xrange
 
 
 def clear_log(log):
@@ -75,21 +69,3 @@ def ansi_pattern(text):
 
 def ansi_regex(text):
     return re.compile(ansi_pattern(text), re.I)
-
-
-def random_string(n=5):
-    """Generates a random string with n ascii_letters"""
-    return ''.join(choice(ascii_letters) for _ in xrange(n))
-
-
-def random_time_based_string():
-    """Generates a random long string that contains random ascii_letters and
-    time-based parts.
-
-    The generated strings are meant to be unique, and then can be used to
-    identify log entries even if the stream is shared.
-    """
-    return ''.join(
-        random_string() + part
-        for part in str(time()).split('.')
-    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,7 +98,7 @@ def test_main_when_updating(tmpfolder, capsys, git_mock):
     assert "Update accomplished!" in out
 
 
-def test_main_with_list_actions(capsys, reset_logger):
+def test_main_with_list_actions(capsys, isolated_logger):
     # When putup is called with --list-actions,
     args = ["my-project", "--tox", "--list-actions"]
     cli.main(args)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -22,8 +22,9 @@ from .log_helpers import (
     make_record,
     match_record,
     match_report,
-    random_time_based_string as uniqstr
 )
+
+from .helpers import uniqstr
 
 
 # Preferably, in order to change log levels in tests `caplog.set_level` should

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -25,6 +25,13 @@ from .log_helpers import (
     match_report
 )
 
+# When adding tests to this file, please have in mind that the global shared
+# logging strategy followed by Python and PyScaffold can lead to pain while
+# testing. Try to create a new ReportLogger with a brand new underlying native
+# Logger object as much as possible (see test_pass_handler for an example), and
+# just deactivate the `isolated_logger` fixture with the `original_logger` mark
+# if really necessary.
+
 
 @pytest.fixture
 def uniq_raw_logger():

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -8,7 +8,7 @@ import pytest
 
 from pyscaffold import shell
 
-from .log_helpers import random_time_based_string as uniqstr
+from .helpers import uniqstr
 
 
 def test_ShellCommand(tmpfolder):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import logging
+import re
 from os.path import exists as path_exists
 
 import pytest
 
 from pyscaffold import shell
 
-from .log_helpers import match_last_report
+from .log_helpers import random_time_based_string as uniqstr
 
 
 def test_ShellCommand(tmpfolder):
@@ -39,11 +40,11 @@ def test_command_exists():
 def test_pretend_command(caplog):
     caplog.set_level(logging.INFO)
     # When command runs under pretend flag,
+    name = uniqstr()
     touch = shell.ShellCommand('touch')
-    touch('my-file.txt', pretend=True)
+    touch(name, pretend=True)
     # then nothing should be executed
-    assert not path_exists('my-file.txt')
+    assert not path_exists(name)
     # but log should be displayed
-    match = match_last_report(caplog)
-    assert match['activity'] == 'run'
-    assert match['content'] == 'touch my-file.txt'
+    logs = caplog.text
+    assert re.search('run.*touch\s'+name, logs)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -4,14 +4,12 @@ import logging
 import os
 import re
 from os.path import isdir, isfile
-from random import choice
-from time import time
 
 import pytest
 
 from pyscaffold import api, cli, structure
 
-from .log_helpers import random_time_based_string as uniqstr
+from .helpers import uniqstr
 
 
 def test_create_structure(tmpfolder):
@@ -100,8 +98,8 @@ def test_apply_update_rules_to_file(tmpfolder, caplog):
     res = structure.apply_update_rule_to_file(
         fname, (fname, NO_OVERWRITE), opts)
     assert res is None
-    log = caplog.text
-    assert re.search("skip.*" + fname, caplog.text)
+    logs = caplog.text
+    assert re.search("skip.*" + fname, logs)
     # When file does not exist, update is True, but rule is NO_CREATE, do
     # nothing
     opts = {"update": True}

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
 import logging
+import os
+import re
 from os.path import isdir, isfile
 from random import choice
 from time import time
@@ -99,14 +100,15 @@ def test_apply_update_rules_to_file(tmpfolder, caplog):
     res = structure.apply_update_rule_to_file(
         fname, (fname, NO_OVERWRITE), opts)
     assert res is None
-    assert "skip  " + fname in caplog.text
+    log = caplog.text
+    assert re.search("skip.*" + fname, caplog.text)
     # When file does not exist, update is True, but rule is NO_CREATE, do
     # nothing
     opts = {"update": True}
     fname = uniqstr()
     res = structure.apply_update_rule_to_file(fname, (fname, NO_CREATE), opts)
     assert res is None
-    assert "skip  " + fname in caplog.text
+    assert re.search("skip.*" + fname, caplog.text)
 
 
 def test_apply_update_rules(tmpfolder):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3,12 +3,14 @@
 import os
 import logging
 from os.path import isdir, isfile
+from random import choice
+from time import time
 
 import pytest
 
 from pyscaffold import api, cli, structure
 
-from .log_helpers import last_log
+from .log_helpers import random_time_based_string as uniqstr
 
 
 def test_create_structure(tmpfolder):
@@ -92,16 +94,19 @@ def test_apply_update_rules_to_file(tmpfolder, caplog):
     assert res == "a"
     # When file exist, update is True, rule is NO_OVERWRITE, do nothing
     opts = {"update": True}
-    tmpfolder.join("a").write("content")
-    res = structure.apply_update_rule_to_file("a", ("a", NO_OVERWRITE), opts)
+    fname = uniqstr()
+    tmpfolder.join(fname).write("content")
+    res = structure.apply_update_rule_to_file(
+        fname, (fname, NO_OVERWRITE), opts)
     assert res is None
-    assert "skip  a" in last_log(caplog)
+    assert "skip  " + fname in caplog.text
     # When file does not exist, update is True, but rule is NO_CREATE, do
     # nothing
     opts = {"update": True}
-    res = structure.apply_update_rule_to_file("b", ("b", NO_CREATE), opts)
+    fname = uniqstr()
+    res = structure.apply_update_rule_to_file(fname, (fname, NO_CREATE), opts)
     assert res is None
-    assert "skip  b" in last_log(caplog)
+    assert "skip  " + fname in caplog.text
 
 
 def test_apply_update_rules(tmpfolder):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ import pytest
 from pyscaffold import templates, utils
 from pyscaffold.exceptions import InvalidIdentifier
 
-from .log_helpers import random_time_based_string as uniqstr
+from .helpers import uniqstr
 
 
 def test_chdir(caplog, tmpdir, isolated_logger):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ from pyscaffold.exceptions import InvalidIdentifier
 from .log_helpers import random_time_based_string as uniqstr
 
 
-def test_chdir(caplog, tmpdir):
+def test_chdir(caplog, tmpdir, isolated_logger):
     caplog.set_level(logging.INFO)
     curr_dir = os.getcwd()
     dname = uniqstr()  # Use a unique name to get easily identifiable logs

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ deps =
     django
     cookiecutter
     pytest-virtualenv
+    pytest-xdist

--- a/tox.ini
+++ b/tox.ini
@@ -13,3 +13,6 @@ deps =
     cookiecutter
     pytest-virtualenv
     pytest-xdist
+# We keep pytest-xdist in the test dependencies, so the developer can easily
+# opt-in for distributed tests by adding, for example, the `-n 15` arguments in
+# the command-line.


### PR DESCRIPTION
This PR is an attempt to solve issue #170.

I have removed order-dependent test helpers and used unique names instead. Additionally, this PR introduces a new context fixture in an attempt to better isolate the logging usage in the tests.

An error (previously undetected) in the chdir logging is also corrected.

However, the results of the tests are still non-deterministic: in some occasions `caplog.text` is unexpectedly blank as indicated by the CI logs. Any tip/hunch/help on this issue is more then welcome, I couldn't completely figure it out yet.

(Who would say, logging would be the most difficult thing to test??)

Regarding performance: in the CI, the speed improvement is not very noticeable (in part because of the setup time and the system tests in bash that do not run in parallel - running everything inside pytest as suggested in #120 could help).