### PR TITLE
Increase minimum setuptools version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Development version
 Version 3.1
 -----------
 
+- Moved ``entry_points`` and ``setup_requires`` to ``setup.cfg``, issue #176
+- Updated ``travis.yml`` template, issue #181
+- Set ``install_requires`` to setuptools>=31
 - Better isolation of unit tests, issue #119
 - Updated tox template, issues #160 & #161
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ packages = find:
 include_package_data = True
 package_dir =
     =src
-install_requires = setuptools>=30.3.0
+install_requires = setuptools>=31
 tests_require = pytest; pytest-cov; pytest-virtualenv; pytest-xdist
 # We keep pytest-xdist in the test dependencies, so the developer can easily
 # opt-in for distributed tests by adding, for example, the `-n 15` arguments in

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -53,10 +53,10 @@ class InvalidIdentifier(RuntimeError):
 
 
 class OldSetuptools(RuntimeError):
-    """PyScaffold requires a recent version of setuptools (>= 12)."""
+    """PyScaffold requires a recent version of setuptools."""
 
     DEFAULT_MESSAGE = (
-        "Your setuptools version is too old (<30.3.0). "
+        "Your setuptools version is too old (<31). "
         "Use `pip install -U setuptools` to upgrade.\n"
         "If you have the deprecated `distribute` package installed "
         "remove it or update to version 0.7.3.")

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -281,7 +281,7 @@ def check_setuptools_version():
             "Due to a bug in setuptools, PyScaffold currently needs at least "
             "Python 3.4! Install PyScaffold 2.5 for Python 2.7 support.")
 
-    setuptools_too_old = LooseVersion(setuptools_ver) < LooseVersion('30.3.0')
+    setuptools_too_old = LooseVersion(setuptools_ver) < LooseVersion('31')
     setuptools_scm_check_failed = VERSION_CLASS is None
     if setuptools_too_old or setuptools_scm_check_failed:
         raise OldSetuptools


### PR DESCRIPTION
This should be necessary in order to allow the inclusion of ``entry_points`` in ``setup.cfg``. Additionally, some already resolved issue were added to the ``CHANGELOG.rst``.

@abravalheri It seems that ``options.entry_points`` works already with setuptools version 31 and above. At least it does on my machine. Could you check if it is the same for you? 