### PR TITLE
pre-commit: No need to exclude untracked things

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '^(src/pyscaffold/contrib|.tox|build|dist|.eggs|docs/conf.py|docs/gfx)'
+exclude: '^(src/pyscaffold/contrib|docs/conf.py|docs/gfx)'
 
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks

--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -1,4 +1,4 @@
-exclude: '^(.tox|build|dist|.eggs|docs/conf.py)'
+exclude: '^docs/conf.py'
 
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
pre-commit will only ever call linters with files that are checked in