### PR TITLE
Allow updating of update.cfg

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
-source = */pyscaffold/*
+source = pyscaffold
 omit =
     */PyScaffold*.egg/*
     */pyscaffold/contrib/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,5 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # default: never
+git:
+  depth: 99999   # avoids shallow checkouts which interfere with setuptools_scm way of determining PyScaffold's version

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Version 3.1
 - Set ``install_requires`` to setuptools>=31
 - Better isolation of unit tests, issue #119
 - Updated tox template, issues #160 & #161
+- Use ``pkg_resources.parse_version`` instead of old ``LooseVersion`` for parsing
 
 
 Current versions

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Version 3.1
 - Better isolation of unit tests, issue #119
 - Updated tox template, issues #160 & #161
 - Use ``pkg_resources.parse_version`` instead of old ``LooseVersion`` for parsing
+- Use ``ConfigUpdater`` instead of ``ConfigParser``
 
 
 Current versions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ except FileNotFoundError:
 
 try:
     import sphinx
-    from packaging.version import parse as parse_version
+    from pkg_resources import parse_version
 
     cmd_line_template = "sphinx-apidoc -f -o {outputdir} {moduledir}"
     cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,13 +42,13 @@ except FileNotFoundError:
 
 try:
     import sphinx
-    from distutils.version import LooseVersion
+    from packaging.version import parse as parse_version
 
     cmd_line_template = "sphinx-apidoc -f -o {outputdir} {moduledir}"
     cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
 
     args = cmd_line.split(" ")
-    if LooseVersion(sphinx.__version__) >= LooseVersion('1.7'):
+    if parse_version(sphinx.__version__) >= parse_version('1.7'):
         args = args[1:]
 
     apidoc.main(args)

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -212,7 +212,7 @@ remove a feature which was once added.
 
 .. _setuptools: http://setuptools.readthedocs.io/en/latest/setuptools.html
 .. _setuptools' documentation: http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
-.. _namespace packages: http://pythonhosted.org/setuptools/setuptools.html#namespace-packages
+.. _namespace packages: https://packaging.python.org/guides/packaging-namespace-packages/
 .. _Sphinx: http://www.sphinx-doc.org/
 .. _Read the Docs: https://readthedocs.org/
 .. _tox documentation: http://tox.readthedocs.org/en/latest/

--- a/src/pyscaffold/api/__init__.py
+++ b/src/pyscaffold/api/__init__.py
@@ -21,6 +21,10 @@ from ..structure import (
     create_structure,
     define_structure
 )
+from ..update import (
+    version_migration,
+    invoke_action
+)
 from . import helpers
 
 
@@ -252,6 +256,7 @@ DEFAULT_ACTIONS = [
     define_structure,
     verify_project_dir,
     apply_update_rules,
+    version_migration,
     create_structure,
     init_git
 ]
@@ -317,7 +322,7 @@ def create_project(opts=None, **kwargs):
 
     # call the actions to generate final struct and opts
     struct = {}
-    struct, opts = reduce(lambda acc, f: _invoke(f, *acc),
+    struct, opts = reduce(lambda acc, f: invoke_action(f, *acc),
                           actions, (struct, opts))
     return struct, opts
 
@@ -331,12 +336,3 @@ def _activate(extension, actions):
         actions = extension(actions)
 
     return actions
-
-
-def _invoke(action, struct, opts):
-    """Invoke action with proper logging."""
-    logger.report('invoke', helpers.get_id(action))
-    with logger.indent():
-        struct, opts = action(struct, opts)
-
-    return struct, opts

--- a/src/pyscaffold/api/__init__.py
+++ b/src/pyscaffold/api/__init__.py
@@ -17,11 +17,11 @@ from ..exceptions import (
 )
 from ..log import logger, configure_logger
 from ..structure import (
-    apply_update_rules,
     create_structure,
     define_structure
 )
 from ..update import (
+    apply_update_rules,
     version_migration,
     invoke_action
 )

--- a/src/pyscaffold/api/__init__.py
+++ b/src/pyscaffold/api/__init__.py
@@ -265,7 +265,7 @@ def create_project(opts=None, **kwargs):
         **kwargs: extra options, passed as keyword arguments
 
     Returns:
-        list: list of actions
+        tuple: a tuple of `struct` and `opts` dictionary
 
     Valid options include:
 
@@ -315,8 +315,11 @@ def create_project(opts=None, **kwargs):
     configure_logger(opts)
     actions = discover_actions(opts.get('extensions', []))
 
-    # call the actions
-    return reduce(lambda acc, f: _invoke(f, *acc), actions, ({}, opts))
+    # call the actions to generate final struct and opts
+    struct = {}
+    struct, opts = reduce(lambda acc, f: _invoke(f, *acc),
+                          actions, (struct, opts))
+    return struct, opts
 
 
 # -------- Auxiliary functions --------

--- a/src/pyscaffold/api/helpers.py
+++ b/src/pyscaffold/api/helpers.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from ..exceptions import ActionNotFound
 from ..log import logger
 from ..structure import FileOp, define_structure
+from ..utils import get_id
 
 logger = logger  # Sphinx workaround to force documenting imported members
 """Logger wrapper, that provides methods like :obj:`~.ReportLogger.report`.
@@ -277,26 +278,6 @@ def unregister(actions, reference):
     """
     position = _find(actions, reference)
     return actions[:position] + actions[position+1:]
-
-
-def get_id(function):
-    """Given a function, calculate its identifier.
-
-    A identifier is a string in the format ``<module name>:<function name>``,
-    similarly to the convention used for setuptools entry points.
-
-    Note:
-        This function does not return a Python 3 ``__qualname__`` equivalent.
-        If the function is nested inside another function or class, the parent
-        name is ignored.
-
-    Args:
-        function (callable): function object
-
-    Returns:
-        str: identifier
-    """
-    return '{}:{}'.format(function.__module__, function.__name__)
 
 
 def _find(actions, name):

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -8,8 +8,9 @@ import logging
 import os.path
 import sys
 
-import pyscaffold
+from packaging.version import parse as parse_version
 
+from . import __version__ as pyscaffold_version
 from . import api, info, shell, templates, utils
 from .api.helpers import get_id
 from .log import ReportFormatter
@@ -78,7 +79,7 @@ def add_default_args(parser):
         '-V',
         '--version',
         action='version',
-        version='PyScaffold {ver}'.format(ver=pyscaffold.__version__))
+        version='PyScaffold {ver}'.format(ver=pyscaffold_version))
     parser.add_argument(
         "-v",
         "--verbose",
@@ -171,8 +172,9 @@ def run_scaffold(opts):
     if opts['update'] and not opts['force']:
         note = "Update accomplished!\n" \
                "Please check if your setup.cfg still complies with:\n" \
-               "http://pyscaffold.org/en/v{}/configuration.html"
-        print(note.format(pyscaffold.__version__))
+               "https://pyscaffold.org/en/v{}/configuration.html"
+        base_version = parse_version(pyscaffold_version).base_version
+        print(note.format(base_version))
 
 
 def list_actions(opts):

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -12,8 +12,8 @@ from pkg_resources import parse_version
 
 from . import __version__ as pyscaffold_version
 from . import api, info, shell, templates, utils
-from .api.helpers import get_id
 from .log import ReportFormatter
+from .utils import get_id
 
 
 def add_default_args(parser):

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -8,7 +8,7 @@ import logging
 import os.path
 import sys
 
-from packaging.version import parse as parse_version
+from pkg_resources import parse_version
 
 from . import __version__ as pyscaffold_version
 from . import api, info, shell, templates, utils

--- a/src/pyscaffold/contrib/__init__.py
+++ b/src/pyscaffold/contrib/__init__.py
@@ -12,7 +12,7 @@ Currently the contrib packages are:
 
 1) setuptools_scm v1.17.0
 2) pytest-runner 3.0
-3) configupdater 0.1
+3) configupdater 0.2
 
 The packages/modules were just copied over.
 """

--- a/src/pyscaffold/contrib/__init__.py
+++ b/src/pyscaffold/contrib/__init__.py
@@ -12,7 +12,7 @@ Currently the contrib packages are:
 
 1) setuptools_scm v1.17.0
 2) pytest-runner 3.0
-3) configupdater 0.2
+3) configupdater 0.3
 
 The packages/modules were just copied over.
 """

--- a/src/pyscaffold/contrib/__init__.py
+++ b/src/pyscaffold/contrib/__init__.py
@@ -12,6 +12,7 @@ Currently the contrib packages are:
 
 1) setuptools_scm v1.17.0
 2) pytest-runner 3.0
+3) configupdater 0.1
 
 The packages/modules were just copied over.
 """

--- a/src/pyscaffold/contrib/configupdater.py
+++ b/src/pyscaffold/contrib/configupdater.py
@@ -1,0 +1,987 @@
+"""Configuration file updater.
+
+A configuration file consists of sections, lead by a "[section]" header,
+and followed by "name: value" entries, with continuations and such in
+the style of RFC 822.
+
+The basic idea of ConfigUpdater is that a configuration file consists of
+three kinds of building blocks: sections, comments and spaces for separation.
+A section itself consists of three kinds of blocks: options, comments and
+spaces. This gives us the corresponding data structures to describe a
+configuration file.
+
+A general block object contains the lines which were parsed and make up
+the block. If a block object was not changed then during writing the same
+lines that were parsed will be used to express the block. In case a block,
+e.g. an option, was changed, it is marked as `updated` and its values will
+be transformed into a corresponding string during an update of a
+configuration file.
+
+
+.. note::
+
+   ConfigUpdater was created by starting from Python's ConfigParser source
+   code and changing it according to my needs. Thus this source code
+   is subject to the PSF License in a way but I am not a lawyer.
+"""
+
+import io
+import os
+import re
+import sys
+from abc import ABC
+from collections import OrderedDict as _default_dict
+from collections.abc import MutableMapping
+from configparser import (ConfigParser, DuplicateOptionError,
+                          DuplicateSectionError, Error,
+                          MissingSectionHeaderError, NoOptionError,
+                          NoSectionError, ParsingError)
+
+__all__ = ["NoSectionError", "DuplicateOptionError", "DuplicateSectionError",
+           "NoOptionError", "NoConfigFileReadError", "ParsingError",
+           "MissingSectionHeaderError", "ConfigUpdater"]
+
+
+class NoConfigFileReadError(Error):
+    """Raised when no configuration file was read but update requested."""
+    def __init__(self):
+        super().__init__(
+            "No configuration file was yet read! Use .read(...) first.")
+
+
+# Used in parser getters to indicate the default behaviour when a specific
+# option is not found it to raise an exception. Created to enable 'None' as
+# a valid fallback value.
+_UNSET = object()
+
+
+class Block(ABC):
+    """Abstract Block type holding lines
+
+    Block objects hold original lines from the configuration file and hold
+    a reference to a container wherein the object resides.
+    """
+    def __init__(self, container=None):
+        self._container = container
+        self.lines = []
+        self._updated = False
+
+    def __str__(self):
+        return ''.join(self.lines)
+
+    def __len__(self):
+        return len(self.lines)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.lines == other.lines
+        else:
+            return False
+
+    def _add_line(self, line):
+        self.lines.append(line)
+
+    @property
+    def add_before(self):
+        """Returns a builder inserting a new block before the current block"""
+        idx = self._container.index(self)
+        return BlockBuilder(self._container, type(self), idx)
+
+    @property
+    def add_after(self):
+        """Returns a builder inserting a new block after the current block"""
+        idx = self._container.index(self)
+        return BlockBuilder(self._container, type(self), idx+1)
+
+
+class BlockBuilder(object):
+    """Builder that injects blocks at a given index position."""
+    def __init__(self, container, block_type, idx):
+        self._container = container
+        self._block_type = block_type
+        self._idx = idx
+
+    def comment(self, text, comment_prefix='#'):
+        """Creates a comment block
+
+        Args:
+            text (str): content of comment without \#
+            comment_prefix (str): character indicating start of comment
+
+        Returns:
+            self for chaining
+        """
+        comment = Comment(self._container)
+        if not text.startswith(comment_prefix):
+            text = "{} {}".format(comment_prefix, text)
+        if not text.endswith(os.linesep):
+            text = "{}{}".format(text, os.linesep)
+        comment._add_line(text)
+        self._container.insert(self._idx, comment)
+        self._idx += 1
+        return self
+
+    def section(self, section):
+        """Creates a section block
+
+        Args:
+            section (str or :class:`Section`): name of section or object
+
+        Returns:
+            self for chaining
+        """
+        if self._block_type is not Section:
+            raise ValueError("Sections can only be added at section level!")
+        if isinstance(section, str):
+            # create a new section
+            section = Section(section, container=self._container)
+        elif not isinstance(section, Section):
+            raise ValueError("Parameter must be a string or Section type!")
+        if section.name in [block.name for block in self._container
+                            if isinstance(block, Section)]:
+            raise DuplicateSectionError(section.name)
+        self._container.insert(self._idx, section)
+        self._idx += 1
+        return self
+
+    def space(self, newlines=1):
+        """Creates a vertical space of newlines
+
+        Args:
+            newlines (int): number of empty lines
+
+        Returns:
+            self for chaining
+        """
+        space = Space()
+        for line in range(newlines):
+            space._add_line(os.linesep)
+        self._container.insert(self._idx, space)
+        self._idx += 1
+        return self
+
+    def option(self, key, value=None, **kwargs):
+        """Creates a new option inside a section
+
+        Args:
+            key (str): key of the option
+            value (str or None): value of the option
+            **kwargs: are passed to the constructor of :class:`Option`
+
+        Returns:
+            self for chaining
+        """
+        if self._block_type is not Option:
+            raise ValueError("Options can only be added inside a section!")
+        option = Option(key, value, container=self._container, **kwargs)
+        option.value = value
+        self._container.insert(self._idx, option)
+        self._idx += 1
+        return self
+
+
+class Comment(Block):
+    """Comment block"""
+    def __init__(self, container=None):
+        super().__init__(container)
+
+    def __repr__(self):
+        return '<Comment>'
+
+
+class Space(Block):
+    """Vertical space block of new lines"""
+    def __init__(self, container=None):
+        super().__init__(container)
+
+    def __repr__(self):
+        return '<Space>'
+
+
+class Section(Block, MutableMapping):
+    """Section block holding options
+
+    Attributes:
+        name (str): name of the section
+        updated (bool): indicates name change or a new section
+    """
+    def __init__(self, name, container):
+        self._name = name
+        self._structure = list()
+        self._updated = False
+        super().__init__(container)
+
+    # used when constructing the section
+    def _add_option(self, entry):
+        self._structure.append(entry)
+
+    def _add_comment(self):
+        if not isinstance(self._curr_entry, Comment):
+            comment = Comment(self._structure)
+            self._structure.append(comment)
+
+    def _add_space(self):
+        if not isinstance(self._curr_entry, Space):
+            space = Space(self._structure)
+            self._structure.append(space)
+
+    @property
+    def _curr_entry(self):
+        if self._structure:
+            return self._structure[-1]
+        else:
+            return None
+
+    def _get_option_idx(self, key):
+        idx = [i for i, entry in enumerate(self._structure)
+               if isinstance(entry, Option) and entry.key == key]
+        if idx:
+            return idx[0]
+        else:
+            raise ValueError
+
+    def __str__(self):
+        if not self.updated:
+            s = super().__str__()
+        else:
+            s = "[{}]\n".format(self._name)
+        for entry in self._structure:
+            s += str(entry)
+        return s
+
+    def __repr__(self):
+        return '<Section: {}>'.format(self.name)
+
+    def __getitem__(self, key):
+        if key not in self.options():
+            raise KeyError(key)
+        return self._structure[self._get_option_idx(key=key)]
+
+    def __setitem__(self, key, value):
+        if key in self:
+            option = self.__getitem__(key)
+            option.value = value
+        else:
+            option = Option(key, value, container=self._structure)
+            option.value = value
+            self._structure.append(option)
+
+    def __delitem__(self, key):
+        if key not in self.options():
+            raise KeyError(key)
+        idx = self._get_option_idx(key=key)
+        del self._structure[idx]
+
+    def __contains__(self, key):
+        return key in self.options()
+
+    def __len__(self):
+        return len(self._structure)
+
+    def __iter__(self):
+        """Return all entries, not just options"""
+        return self._structure.__iter__()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return (self.name == other.name and
+                    self._structure == other._structure)
+        else:
+            return False
+
+    def option_blocks(self):
+        """Returns option blocks
+
+        Returns:
+            list: list of :class:`Option` blocks
+        """
+        return [entry for entry in self._structure
+                if isinstance(entry, Option)]
+
+    def options(self):
+        """Returns option names
+
+        Returns:
+            list: list of option names as strings
+        """
+        return [option.key for option in self.option_blocks()]
+
+    @property
+    def updated(self):
+        """Returns if the option was changed/updated"""
+        # if no lines were added, treat it as updated since we added it
+        return self._updated or not self.lines
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = str(value)
+        self._updated = True
+
+
+class Option(Block):
+    """Option block holding a key/value pair.
+
+    Attributes:
+        key (str): name of the key
+        value (str): stored value
+        updated (bool): indicates name change or a new section
+    """
+    def __init__(self, key, value, container, delimiter='=',
+                 space_around_delimiters=True):
+        self._key = key
+        self._values = [value]
+        self._value_is_none = value is None
+        self._delimiter = delimiter
+        self._value = None  # will be filled after join_multiline_value
+        self._updated = False
+        self._multiline_value_joined = False
+        self._space_around_delimiters = space_around_delimiters
+        super().__init__(container)
+
+    def _join_multiline_value(self):
+        if not self._multiline_value_joined and not self._value_is_none:
+            # do what `_join_multiline_value` in ConfigParser would do
+            self._value = os.linesep.join(self._values).rstrip()
+            self._multiline_value_joined = True
+
+    def __str__(self):
+        if not self.updated:
+            return super().__str__()
+        if self._value is None:
+            return "{}{}".format(self._key, os.linesep)
+        if self._space_around_delimiters:
+            # no space is needed if we use multi-line arguments
+            suffix = '' if str(self._value).startswith(os.linesep) else ' '
+            delim = " {}{}".format(self._delimiter, suffix)
+        else:
+            delim = self._delimiter
+        return "{}{}{}{}".format(self._key, delim, self._value, os.linesep)
+
+    def __repr__(self):
+        return '<Option: {} = {}>'.format(self.key, self.value)
+
+    @property
+    def updated(self):
+        """Returns if the option was changed/updated"""
+        # if no lines were added, treat it as updated since we added it
+        return self._updated or not self.lines
+
+    @property
+    def key(self):
+        return self._key
+
+    @key.setter
+    def key(self, value):
+        self._join_multiline_value()
+        self._key = value
+        self._updated = True
+
+    @property
+    def value(self):
+        self._join_multiline_value()
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        self._updated = True
+        self._multiline_value_joined = True
+        self._value = value
+        self._values = [value]
+
+    def set_values(self, values, separator=os.linesep, indent=4*' '):
+        """Sets the value to a given list of options, e.g. multi-line values
+
+        Args:
+            values (list): list of values
+            separator (str): separator for values, default: line separator
+            indent (str): indentation depth in case of line separator
+        """
+        self._updated = True
+        self._multiline_value_joined = True
+        self._values = values
+        if separator == os.linesep:
+            values.insert(0, '')
+            separator = separator + indent
+        self._value = separator.join(values)
+
+
+class ConfigUpdater(MutableMapping):
+    """Parser for updating configuration files.
+
+    ConfigUpdater follows the API of ConfigParser with some differences:
+      * inline comments are treated as part of a key's value,
+      * only a single config file can be updated at a time,
+      * empty lines in values are not valid,
+      * the original case of sections and keys are kept,
+      * control over the position of a new section/key.
+
+    Following features are **deliberately not** implemented:
+
+      * interpolation of values,
+      * propagation of parameters from the default section,
+      * conversions of values,
+      * passing key/value-pairs with ``default`` argument,
+      * non-strict mode allowing duplicate sections and keys.
+    """
+    # Regular expressions for parsing section headers and options
+    _SECT_TMPL = r"""
+        \[                                 # [
+        (?P<header>[^]]+)                  # very permissive!
+        \]                                 # ]
+        """
+    _OPT_TMPL = r"""
+        (?P<option>.*?)                    # very permissive!
+        \s*(?P<vi>{delim})\s*              # any number of space/tab,
+                                           # followed by any of the
+                                           # allowed delimiters,
+                                           # followed by any space/tab
+        (?P<value>.*)$                     # everything up to eol
+        """
+    _OPT_NV_TMPL = r"""
+        (?P<option>.*?)                    # very permissive!
+        \s*(?:                             # any number of space/tab,
+        (?P<vi>{delim})\s*                 # optionally followed by
+                                           # any of the allowed
+                                           # delimiters, followed by any
+                                           # space/tab
+        (?P<value>.*))?$                   # everything up to eol
+        """
+    # Compiled regular expression for matching sections
+    SECTCRE = re.compile(_SECT_TMPL, re.VERBOSE)
+    # Compiled regular expression for matching options with typical separators
+    OPTCRE = re.compile(_OPT_TMPL.format(delim="=|:"), re.VERBOSE)
+    # Compiled regular expression for matching options with optional values
+    # delimited using typical separators
+    OPTCRE_NV = re.compile(_OPT_NV_TMPL.format(delim="=|:"), re.VERBOSE)
+    # Compiled regular expression for matching leading whitespace in a line
+    NONSPACECRE = re.compile(r"\S")
+
+    def __init__(self, allow_no_value=False, *, delimiters=('=', ':'),
+                 comment_prefixes=('#', ';'), inline_comment_prefixes=None,
+                 strict=True, space_around_delimiters=True):
+        """Constructor of ConfigUpdater
+
+        Args:
+            allow_no_value (bool): allow keys without a value, default False
+            delimiters (tuple): delimiters for key/value pairs, default =, :
+            comment_prefixes (tuple): prefix of comments, default # and ;
+            inline_comment_prefixes (tuple): prefix of inline comment,
+                default None
+            strict (bool): each section must be unique as well as every key
+                within a section, default True
+            space_around_delimiters (bool): add a space before and after the
+                delimiter, default True
+        """
+        self._filename = None
+        self._space_around_delimiters = space_around_delimiters
+
+        self._dict = _default_dict  # no reason to let the user change this
+        # keeping _sections to keep code aligned with ConfigParser but
+        # _structure takes the actual role instead. Only use self._structure!
+        self._sections = self._dict()
+        self._structure = []
+        self._delimiters = tuple(delimiters)
+        if delimiters == ('=', ':'):
+            self._optcre = self.OPTCRE_NV if allow_no_value else self.OPTCRE
+        else:
+            d = "|".join(re.escape(d) for d in delimiters)
+            if allow_no_value:
+                self._optcre = re.compile(self._OPT_NV_TMPL.format(delim=d),
+                                          re.VERBOSE)
+            else:
+                self._optcre = re.compile(self._OPT_TMPL.format(delim=d),
+                                          re.VERBOSE)
+        self._comment_prefixes = tuple(comment_prefixes or ())
+        self._inline_comment_prefixes = tuple(inline_comment_prefixes or ())
+        self._strict = strict
+        self._allow_no_value = allow_no_value
+        # Options from ConfigParser that we need to set constantly
+        self._empty_lines_in_values = False
+
+    @property
+    def _curr_block(self):
+        if self._structure:
+            return self._structure[-1]
+        else:
+            return None
+
+    def _get_section_idx(self, name):
+        idx = [i for i, entry in enumerate(self._structure)
+               if isinstance(entry, Section) and entry.name == name]
+        if idx:
+            return idx[0]
+        else:
+            raise ValueError
+
+    def read(self, filename, encoding=None):
+        """Read and parse a filename.
+
+        Args:
+            filename (str): path to file
+            encoding (str): encoding of file, default None
+        """
+        with open(filename, encoding=encoding) as fp:
+            self._read(fp, filename)
+        self._filename = os.path.abspath(filename)
+
+    def read_file(self, f, source=None):
+        """Like read() but the argument must be a file-like object.
+
+        The `f` argument must be iterable, returning one line at a time.
+        Optional second argument is the `source` specifying the name of the
+        file being read. If not given, it is taken from f.name. If `f` has no
+        `name` attribute, `<???>` is used.
+
+        Args:
+            f: file like object
+            source (str): reference name for file object, default None
+        """
+        if source is None:
+            try:
+                source = f.name
+            except AttributeError:
+                source = '<???>'
+        self._read(f, source)
+
+    def read_string(self, string, source='<string>'):
+        """Read configuration from a given string.
+
+        Args:
+            string (str): string containing a configuration
+            source (str): reference name for file object, default '<string>'
+        """
+        sfile = io.StringIO(string)
+        self.read_file(sfile, source)
+
+    def optionxform(self, optionstr):
+        """Converts an option key to lower case for unification
+
+        Args:
+            optionstr (str): key name
+
+        Returns:
+            str: key name
+        """
+        return optionstr.lower()
+
+    def _update_curr_block(self, block_type):
+        if not isinstance(self._curr_block, block_type):
+            new_block = block_type(container=self._structure)
+            self._structure.append(new_block)
+
+    def _add_comment(self, line):
+        if isinstance(self._curr_block, Section):
+            self._curr_block._add_comment()
+            self._curr_block._curr_entry._add_line(line)
+        else:
+            self._update_curr_block(Comment)
+            self._curr_block._add_line(line)
+
+    def _add_section(self, sectname, line):
+        new_section = Section(sectname, container=self._structure)
+        new_section._add_line(line)
+        self._structure.append(new_section)
+
+    def _add_option(self, key, vi, value, line):
+        entry = Option(
+            key, value,
+            delimiter=vi,
+            container=self._curr_block._structure,
+            space_around_delimiters=self._space_around_delimiters)
+        entry._add_line(line)
+        self._curr_block._add_option(entry)
+
+    def _add_space(self, line):
+        if isinstance(self._curr_block, Section):
+            self._curr_block._add_space()
+            self._curr_block._curr_entry._add_line(line)
+        else:
+            self._update_curr_block(Space)
+            self._curr_block._add_line(line)
+
+    def _read(self, fp, fpname):
+        """Parse a sectioned configuration file.
+
+        Each section in a configuration file contains a header, indicated by
+        a name in square brackets (`[]`), plus key/value options, indicated by
+        `name` and `value` delimited with a specific substring (`=` or `:` by
+        default).
+
+        Values can span multiple lines, as long as they are indented deeper
+        than the first line of the value. Depending on the parser's mode, blank
+        lines may be treated as parts of multiline values or ignored.
+
+        Configuration files may include comments, prefixed by specific
+        characters (`#` and `;` by default). Comments may appear on their own
+        in an otherwise empty line or may be entered in lines holding values or
+        section names.
+
+        Note: This method was borrowed from ConfigParser and we keep this
+        mess here as close as possible to the original messod (pardon
+        this german pun) for consistency reasons and later upgrades.
+        """
+        self._structure = []
+        elements_added = set()
+        cursect = None                        # None, or a dictionary
+        sectname = None
+        optname = None
+        lineno = 0
+        indent_level = 0
+        e = None                              # None, or an exception
+        for lineno, line in enumerate(fp, start=1):
+            comment_start = sys.maxsize
+            # strip inline comments
+            inline_prefixes = {p: -1 for p in self._inline_comment_prefixes}
+            while comment_start == sys.maxsize and inline_prefixes:
+                next_prefixes = {}
+                for prefix, index in inline_prefixes.items():
+                    index = line.find(prefix, index+1)
+                    if index == -1:
+                        continue
+                    next_prefixes[prefix] = index
+                    if index == 0 or (index > 0 and line[index-1].isspace()):
+                        comment_start = min(comment_start, index)
+                inline_prefixes = next_prefixes
+            # strip full line comments
+            for prefix in self._comment_prefixes:
+                if line.strip().startswith(prefix):
+                    comment_start = 0
+                    self._add_comment(line)  # HOOK
+                    break
+            if comment_start == sys.maxsize:
+                comment_start = None
+            value = line[:comment_start].strip()
+            if not value:
+                if self._empty_lines_in_values:
+                    # add empty line to the value, but only if there was no
+                    # comment on the line
+                    if (comment_start is None and
+                            cursect is not None and
+                            optname and
+                            cursect[optname] is not None):
+                        cursect[optname].append('')  # newlines added at join
+                        self._curr_block._curr_entry._add_line(line)  # HOOK
+                else:
+                    # empty line marks end of value
+                    indent_level = sys.maxsize
+                if comment_start is None:
+                    self._add_space(line)
+                continue
+            # continuation line?
+            first_nonspace = self.NONSPACECRE.search(line)
+            cur_indent_level = first_nonspace.start() if first_nonspace else 0
+            if (cursect is not None and optname and
+                    cur_indent_level > indent_level):
+                cursect[optname].append(value)
+                self._curr_block._curr_entry._add_line(line)  # HOOK
+            # a section header or option header?
+            else:
+                indent_level = cur_indent_level
+                # is it a section header?
+                mo = self.SECTCRE.match(value)
+                if mo:
+                    sectname = mo.group('header')
+                    if sectname in self._sections:
+                        if self._strict and sectname in elements_added:
+                            raise DuplicateSectionError(sectname, fpname,
+                                                        lineno)
+                        cursect = self._sections[sectname]
+                        elements_added.add(sectname)
+                    else:
+                        cursect = self._dict()
+                        self._sections[sectname] = cursect
+                        elements_added.add(sectname)
+                    # So sections can't start with a continuation line
+                    optname = None
+                    self._add_section(sectname, line)  # HOOK
+                # no section header in the file?
+                elif cursect is None:
+                    raise MissingSectionHeaderError(fpname, lineno, line)
+                # an option line?
+                else:
+                    mo = self._optcre.match(value)
+                    if mo:
+                        optname, vi, optval = mo.group('option', 'vi', 'value')
+                        if not optname:
+                            e = self._handle_error(e, fpname, lineno, line)
+                        optname = self.optionxform(optname.rstrip())
+                        if (self._strict and
+                                (sectname, optname) in elements_added):
+                            raise DuplicateOptionError(sectname, optname,
+                                                       fpname, lineno)
+                        elements_added.add((sectname, optname))
+                        # This check is fine because the OPTCRE cannot
+                        # match if it would set optval to None
+                        if optval is not None:
+                            optval = optval.strip()
+                            cursect[optname] = [optval]
+                        else:
+                            # valueless option handling
+                            cursect[optname] = None
+                        self._add_option(optname, vi, optval, line)  # HOOK
+                    else:
+                        # a non-fatal parsing error occurred. set up the
+                        # exception but keep going. the exception will be
+                        # raised at the end of the file and will contain a
+                        # list of all bogus lines
+                        e = self._handle_error(e, fpname, lineno, line)
+        # if any parsing errors occurred, raise an exception
+        if e:
+            raise e
+
+    def _handle_error(self, exc, fpname, lineno, line):
+        if not exc:
+            exc = ParsingError(fpname)
+        exc.append(lineno, repr(line))
+        return exc
+
+    def write(self, fp):
+        """Write an .ini-format representation of the configuration state.
+
+        Args:
+            fp (file-like object): open file handle
+        """
+        fp.write(str(self))
+
+    def update_file(self):
+        """Update the read-in configuration file.
+        """
+        if self._filename is None:
+            raise NoConfigFileReadError()
+        with open(self._filename, 'w') as fb:
+            self.write(fb)
+
+    def validate_format(self, **kwargs):
+        """Call ConfigParser to validate config
+
+        Args:
+            kwargs: are passed to :class:`configparser.ConfigParser`
+        """
+        args = dict(
+            dict_type=self._dict,
+            allow_no_value=self._allow_no_value,
+            inline_comment_prefixes=self._inline_comment_prefixes,
+            strict=self._strict,
+            empty_lines_in_values=self._empty_lines_in_values
+        )
+        args.update(kwargs)
+        parser = ConfigParser(**args)
+        updated_cfg = str(self)
+        parser.read_string(updated_cfg)
+
+    def sections_blocks(self):
+        """Returns all section blocks
+
+        Returns:
+            list: list of :class:`Section` blocks
+        """
+        return [block for block in self._structure
+                if isinstance(block, Section)]
+
+    def sections(self):
+        """Return a list of section names
+
+        Returns:
+            list: list of section names
+        """
+        return [section.name for section in self.sections_blocks()]
+
+    def __str__(self):
+        return ''.join(str(block) for block in self._structure)
+
+    def __getitem__(self, key):
+        for section in self.sections_blocks():
+            if section.name == key:
+                return section
+        else:
+            raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        if not isinstance(value, Section):
+            raise ValueError("Value must be of type Section!")
+        if isinstance(key, str) and key in self:
+            idx = self._get_section_idx(key)
+            del self._structure[idx]
+            self._structure.insert(idx, value)
+        else:
+            # name the section by the key
+            value.name = key
+            self.add_section(value)
+
+    def __delitem__(self, section):
+        if not self.has_section(section):
+            raise KeyError(section)
+        self.remove_section(section)
+
+    def __contains__(self, key):
+        return self.has_section(key)
+
+    def __len__(self):
+        """Number of all blocks, not just sections"""
+        return len(self._structure)
+
+    def __iter__(self):
+        """Iterate over all blocks, not just sections"""
+        return self._structure.__iter__()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self._structure == other._structure
+        else:
+            return False
+
+    def add_section(self, section):
+        """Create a new section in the configuration.
+
+        Raise DuplicateSectionError if a section by the specified name
+        already exists. Raise ValueError if name is DEFAULT.
+
+        Args:
+            section (str or :class:`Section`): name or Section type
+        """
+        if section in self.sections():
+            raise DuplicateSectionError(section)
+        if isinstance(section, str):
+            # create a new section
+            section = Section(section, container=self._structure)
+        elif not isinstance(section, Section):
+            raise ValueError("Parameter must be a string or Section type!")
+        self._structure.append(section)
+
+    def has_section(self, section):
+        """Returns whether the given section exists.
+
+        Args:
+            section (str): name of section
+
+        Returns:
+            bool: wether the section exists
+        """
+        return section in self.sections()
+
+    def options(self, section):
+        """Returns list of configuration options for the named section.
+
+        Args:
+            section (str): name of section
+
+        Returns:
+            list: list of option names
+        """
+        if not self.has_section(section):
+            raise NoSectionError(section) from None
+        return self.__getitem__(section).options()
+
+    def get(self, section, option):
+        """Gets an option value for a given section.
+
+        Args:
+            section (str): section name
+            option (str): option name
+
+        Returns:
+            :class:`Option`: Option object holding key/value pair
+        """
+        if not self.has_section(section):
+            raise NoSectionError(section) from None
+
+        section = self.__getitem__(section)
+        option = self.optionxform(option)
+        try:
+            value = section[option]
+        except KeyError:
+            raise NoOptionError(option, section)
+
+        return value
+
+    def items(self, section=_UNSET):
+        """Return a list of (name, value) tuples for options or sections.
+
+        If section is given, return a list of tuples with (name, value) for
+        each option in the section. Otherwise, return a list of tuples with
+        (section_name, section_type) for each section.
+
+        Args:
+            section (str): optional section name, default UNSET
+
+        Returns:
+            list: list of :class:`Section` or :class:`Option` objects
+        """
+        if section is _UNSET:
+            return [(sect.name, sect) for sect in self.sections_blocks()]
+
+        section = self.__getitem__(section)
+        return [(opt.key, opt) for opt in section.option_blocks()]
+
+    def has_option(self, section, option):
+        """Checks for the existence of a given option in a given section.
+
+        Args:
+            section (str): name of section
+            option (str): name of option
+
+        Returns:
+            bool: whether the option exists in the given section
+        """
+        if section not in self.sections():
+            return False
+        else:
+            option = self.optionxform(option)
+            return option in self[section]
+
+    def set(self, section, option, value=None):
+        """Set an option.
+
+        Args:
+            section (str): section name
+            option (str): option name
+            value (str): value, default None
+        """
+        try:
+            section = self.__getitem__(section)
+        except KeyError:
+            raise NoSectionError(section) from None
+        option = self.optionxform(option)
+        if option in section:
+            section[option].value = value
+        else:
+            section[option] = value
+
+    def remove_option(self, section, option):
+        """Remove an option.
+
+        Args:
+            section (str): section name
+            option (str): option name
+
+        Returns:
+            bool: whether the option was actually removed
+        """
+        try:
+            section = self.__getitem__(section)
+        except KeyError:
+            raise NoSectionError(section) from None
+        option = self.optionxform(option)
+        existed = option in section.options()
+        if existed:
+            del section[option]
+        return existed
+
+    def remove_section(self, name):
+        """Remove a file section.
+
+        Args:
+            name: name of the section
+
+        Returns:
+            bool: whether the section was actually removed
+        """
+        existed = self.has_section(name)
+        if existed:
+            idx = self._get_section_idx(name)
+            del self._structure[idx]
+        return existed

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -10,7 +10,7 @@ class ActionNotFound(KeyError):
 
     def __init__(self, name, *args, **kwargs):
         message = ActionNotFound.__doc__[:-1] + ': `{}`'.format(name)
-        super(ActionNotFound, self).__init__(message, *args, **kwargs)
+        super().__init__(message, *args, **kwargs)
 
 
 class DirectoryAlreadyExists(RuntimeError):
@@ -29,7 +29,7 @@ class GitNotInstalled(RuntimeError):
     DEFAULT_MESSAGE = "Make sure git is installed and working."
 
     def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
-        super(GitNotInstalled, self).__init__(message, *args, **kwargs)
+        super().__init__(message, *args, **kwargs)
 
 
 class GitNotConfigured(RuntimeError):
@@ -42,7 +42,7 @@ class GitNotConfigured(RuntimeError):
         "to set your account's default identity.")
 
     def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
-        super(GitNotConfigured, self).__init__(message, *args, **kwargs)
+        super().__init__(message, *args, **kwargs)
 
 
 class InvalidIdentifier(RuntimeError):
@@ -62,7 +62,7 @@ class OldSetuptools(RuntimeError):
         "remove it or update to version 0.7.3.")
 
     def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
-        super(OldSetuptools, self).__init__(message, *args, **kwargs)
+        super().__init__(message, *args, **kwargs)
 
 
 class PyScaffoldTooOld(RuntimeError):
@@ -73,7 +73,7 @@ class PyScaffoldTooOld(RuntimeError):
         "Are you trying to update a pre 3.0 version?")
 
     def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
-        super(PyScaffoldTooOld, self).__init__(message, *args, **kwargs)
+        super().__init__(message, *args, **kwargs)
 
 
 class NoPyScaffoldProject(RuntimeError):
@@ -83,11 +83,11 @@ class NoPyScaffoldProject(RuntimeError):
         "Could not update project. Was it generated with PyScaffold?")
 
     def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
-        super(NoPyScaffoldProject, self).__init__(message, *args, **kwargs)
+        super().__init__(message, *args, **kwargs)
 
 
 class ShellCommandException(RuntimeError):
     """Outputs proper logging when a ShellCommand fails"""
 
     def __init__(self, message, *args, **kwargs):
-        super(ShellCommandException, self).__init__(message, *args, **kwargs)
+        super().__init__(message, *args, **kwargs)

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -113,7 +113,7 @@ def project(opts):
 
     opts = copy.deepcopy(opts)
     try:
-        cfg = read_setupcfg(opts['project'])
+        cfg = read_setupcfg(opts['project']).to_dict()
         if not cfg.has_section('pyscaffold'):
             raise PyScaffoldTooOld
         pyscaffold = cfg['pyscaffold']
@@ -127,11 +127,9 @@ def project(opts):
         opts.setdefault('email', metadata['author-email'])
         opts.setdefault('url', metadata['url'])
         opts.setdefault('description', metadata['description'])
-        opts.setdefault('license',
-                        best_fit_license(metadata['license'].value))
+        opts.setdefault('license', best_fit_license(metadata['license']))
         # Additional parameters compare with `get_default_options`
-        opts['classifiers'] = (metadata['classifiers']
-                               .value.strip().split('\n'))
+        opts['classifiers'] = metadata['classifiers'].strip().split('\n')
         # complement the cli extensions with the ones from configuration
         if 'extensions' in pyscaffold:
             cfg_extensions = pyscaffold['extensions'].strip().split('\n')

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -5,7 +5,9 @@ Provide general information about the system, user etc.
 
 import copy
 import getpass
+import logging
 import socket
+import traceback
 from operator import itemgetter
 
 from . import shell
@@ -114,7 +116,7 @@ def project(opts):
     opts = copy.deepcopy(opts)
     try:
         cfg = read_setupcfg(opts['project']).to_dict()
-        if not cfg.has_section('pyscaffold'):
+        if 'pyscaffold' not in cfg:
             raise PyScaffoldTooOld
         pyscaffold = cfg['pyscaffold']
         metadata = cfg['metadata']
@@ -144,6 +146,8 @@ def project(opts):
                         opts[extension.name] = ext_value
                     opts['extensions'].append(extension_obj)
     except Exception as e:
+        if opts['log_level'] <= logging.INFO:
+            traceback.print_stack()
         raise NoPyScaffoldProject from e
     return opts
 

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -8,7 +8,7 @@ import getpass
 import socket
 from operator import itemgetter
 
-from . import shell, utils
+from . import shell
 from .exceptions import (
     GitNotConfigured,
     GitNotInstalled,
@@ -127,9 +127,11 @@ def project(opts):
         opts.setdefault('email', metadata['author-email'])
         opts.setdefault('url', metadata['url'])
         opts.setdefault('description', metadata['description'])
-        opts.setdefault('license', utils.best_fit_license(metadata['license']))
+        opts.setdefault('license',
+                        best_fit_license(metadata['license'].value))
         # Additional parameters compare with `get_default_options`
-        opts['classifiers'] = metadata['classifiers'].strip().split('\n')
+        opts['classifiers'] = (metadata['classifiers']
+                               .value.strip().split('\n'))
         # complement the cli extensions with the ones from configuration
         if 'extensions' in pyscaffold:
             cfg_extensions = pyscaffold['extensions'].strip().split('\n')

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -129,7 +129,6 @@ def project(opts):
         opts.setdefault('license', utils.best_fit_license(metadata['license']))
         # Additional parameters compare with `get_default_options`
         opts['classifiers'] = metadata['classifiers'].strip().split('\n')
-        opts['version'] = pyscaffold['version']
         # complement the cli extensions with the ones from configuration
         if 'extensions' in pyscaffold:
             cfg_extensions = pyscaffold['extensions'].strip().split('\n')

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -146,7 +146,7 @@ def project(opts):
                         opts[extension.name] = ext_value
                     opts['extensions'].append(extension_obj)
     except Exception as e:
-        if opts['log_level'] <= logging.INFO:
+        if opts.get('log_level', logging.ERROR) <= logging.INFO:
             traceback.print_stack()
         raise NoPyScaffoldProject from e
     return opts

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -7,10 +7,11 @@ import os.path
 import string
 from pkgutil import get_data
 
-from ..utils import list2str
-from ..update import get_setup_requires_version
+from ..utils import list2str, get_setup_requires_version
 from .. import __version__ as pyscaffold_version
 
+
+#: All available licences
 licenses = {"affero": "license_affero_3.0",
             "apache": "license_apache",
             "artistic": "license_artistic_2.0",

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -7,6 +7,8 @@ import os.path
 import string
 from pkgutil import get_data
 
+from .. import __version__ as pyscaffold_version
+
 licenses = {"affero": "license_affero_3.0",
             "apache": "license_apache",
             "artistic": "license_artistic_2.0",
@@ -83,7 +85,7 @@ def setup_cfg(opts):
 
     # [pyscaffold] section used for later updates
     pyscaffold_config = [
-        'version = ' + opts['version'],
+        'version = ' + pyscaffold_version,
         'package = ' + opts['package']
     ]
 

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -7,6 +7,8 @@ import os.path
 import string
 from pkgutil import get_data
 
+from ..utils import list2str
+from ..update import get_setup_requires_version
 from .. import __version__ as pyscaffold_version
 
 licenses = {"affero": "license_affero_3.0",
@@ -69,7 +71,6 @@ def setup_cfg(opts):
     Returns:
         str: file content as string
     """
-    from ..utils import list2str
     template = get_template("setup_cfg")
     opts['classifiers_str'] = list2str(
         opts['classifiers'],
@@ -77,6 +78,8 @@ def setup_cfg(opts):
         brackets=False,
         quotes=False,
         sep='')
+
+    opts['setup_requires_str'] = get_setup_requires_version()
 
     opts['requirements_str'] = (
         'install_requires =\n' + _add_list(opts['requirements'])

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -12,10 +12,6 @@ url = ${url}
 long-description = file: README.rst
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = any
-# Add here all kinds of additional classifiers as defined under
-# https://pypi.python.org/pypi?%3Aaction=list_classifiers
-classifiers =
-    ${classifiers_str}
 
 [options]
 zip_safe = False
@@ -25,9 +21,6 @@ package_dir =
     =src
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = ${setup_requires_str}
-# Add here dependencies of your project (semicolon/line-separated), e.g.
-# install_requires = numpy; scipy
-${requirements_str}
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 
@@ -104,4 +97,3 @@ exclude =
 [pyscaffold]
 # PyScaffold's parameters when the project was created.
 # This will be used when updating. Do not change!
-${pyscaffold}

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -24,7 +24,7 @@ include_package_data = True
 package_dir =
     =src
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
-setup_requires = pyscaffold>=3.0a0,<3.1a0
+setup_requires = ${setup_requires_str}
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # install_requires = numpy; scipy
 ${requirements_str}

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -23,8 +23,8 @@ packages = find:
 include_package_data = True
 package_dir =
     =src
-setup_requires =
-    pyscaffold>=3.0a0,<3.1a0
+# DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
+setup_requires = pyscaffold>=3.0a0,<3.1a0
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 # install_requires = numpy; scipy
 ${requirements_str}

--- a/src/pyscaffold/templates/setup_py.template
+++ b/src/pyscaffold/templates/setup_py.template
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """
     Setup file for ${package}.
+    Use setup.cfg to configure your project.
 
     This file was generated with PyScaffold ${version}.
     PyScaffold helps you to put up the scaffold of your new Python project.

--- a/src/pyscaffold/templates/skeleton.template
+++ b/src/pyscaffold/templates/skeleton.template
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 """
 This is a skeleton file that can serve as a starting point for a Python
-console script. To run this script uncomment the following line in the
-entry_points section in setup.py:
+console script. To run this script uncomment the following lines in the
+[options.entry_points] section in setup.cfg:
 
-    [console_scripts]
-    fibonacci = ${package}.skeleton:run
+    console_scripts =
+         fibonacci = ${package}.skeleton:run
 
 Then run `python setup.py install` which will install the command `fibonacci`
 inside your current environment.

--- a/src/pyscaffold/templates/sphinx_conf.template
+++ b/src/pyscaffold/templates/sphinx_conf.template
@@ -43,13 +43,13 @@ except FileNotFoundError:
 
 try:
     import sphinx
-    from distutils.version import LooseVersion
+    from packaging.version import parse as parse_version
 
     cmd_line_template = "sphinx-apidoc -f -o {outputdir} {moduledir}"
     cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
 
     args = cmd_line.split(" ")
-    if LooseVersion(sphinx.__version__) >= LooseVersion('1.7'):
+    if parse_version(sphinx.__version__) >= parse_version('1.7'):
         args = args[1:]
 
     apidoc.main(args)

--- a/src/pyscaffold/templates/sphinx_conf.template
+++ b/src/pyscaffold/templates/sphinx_conf.template
@@ -43,7 +43,7 @@ except FileNotFoundError:
 
 try:
     import sphinx
-    from packaging.version import parse as parse_version
+    from pkg_resources import parse_version
 
     cmd_line_template = "sphinx-apidoc -f -o {outputdir} {moduledir}"
     cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)

--- a/src/pyscaffold/templates/sphinx_conf.template
+++ b/src/pyscaffold/templates/sphinx_conf.template
@@ -140,7 +140,10 @@ html_theme = 'alabaster'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    'sidebar_width': '300px',
+    'page_width': '1200px'
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -8,7 +8,7 @@ from functools import reduce
 from os.path import exists as path_exists
 from os.path import join as join_path
 
-from packaging.version import parse as parse_version
+from pkg_resources import parse_version
 
 from . import __version__ as pyscaffold_version
 from .api import helpers

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -4,10 +4,11 @@ Functionality to update one PyScaffold version to another
 """
 import os
 from configparser import ConfigParser
-from distutils.version import LooseVersion
 from functools import reduce
 from os.path import exists as path_exists
 from os.path import join as join_path
+
+from packaging.version import parse as parse_version
 
 from . import __version__ as pyscaffold_version
 from .api import helpers
@@ -131,11 +132,11 @@ def get_curr_version(project_path):
         project_path: path to project
 
     Returns:
-        LooseVersion: version specifier
+        Version: version specifier
     """
     setupcfg = ConfigParser()
     setupcfg.read(join_path(project_path, 'setup.cfg'))
-    return LooseVersion(setupcfg['pyscaffold']['version'])
+    return parse_version(setupcfg['pyscaffold']['version'])
 
 
 def version_migration(struct, opts):
@@ -158,8 +159,8 @@ def version_migration(struct, opts):
 
     # specify how to migrate from one version to another as ordered list
     migration_plans = [
-        (LooseVersion('3.1'), [add_entrypoints,
-                               add_setup_requires])
+        (parse_version('3.1'), [add_entrypoints,
+                                add_setup_requires])
     ]
     for plan_version, plan_actions in migration_plans:
         if curr_version < plan_version:
@@ -223,7 +224,7 @@ def get_setup_requires_version():
         str: requirement string for setup_requires
     """
     require_str = "pyscaffold>={major}.{minor}a0,<{major}.{next_minor}a0"
-    major, minor, *rest = LooseVersion(pyscaffold_version).version
+    major, minor, *rest = parse_version(pyscaffold_version).release
     next_minor = int(minor) + 1
     return require_str.format(major=major, minor=minor, next_minor=next_minor)
 

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -133,8 +133,8 @@ def get_curr_version(project_path):
     Returns:
         Version: version specifier
     """
-    setupcfg = read_setupcfg(project_path)
-    return parse_version(setupcfg['pyscaffold']['version'].value)
+    setupcfg = read_setupcfg(project_path).to_dict()
+    return parse_version(setupcfg['pyscaffold']['version'])
 
 
 def version_migration(struct, opts):

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -3,6 +3,7 @@
 Functionality to update one PyScaffold version to another
 """
 import os
+from configparser import ConfigParser
 from distutils.version import LooseVersion
 from functools import reduce
 from os.path import exists as path_exists
@@ -123,6 +124,20 @@ def invoke_action(action, struct, opts):
     return struct, opts
 
 
+def get_curr_version(project_path):
+    """Retrieves the PyScaffold version that put up the scaffold
+
+    Args:
+        project_path: path to project
+
+    Returns:
+        LooseVersion: version specifier
+    """
+    setupcfg = ConfigParser()
+    setupcfg.read(join_path(project_path, 'setup.cfg'))
+    return LooseVersion(setupcfg['pyscaffold']['version'])
+
+
 def version_migration(struct, opts):
     """Migrations from one version to another
 
@@ -139,7 +154,7 @@ def version_migration(struct, opts):
     if not update:
         return struct, opts
 
-    curr_version = opts['version']
+    curr_version = get_curr_version(opts['project'])
 
     # specify how to migrate from one version to another as ordered list
     migration_plans = [

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -225,7 +225,8 @@ def get_setup_requires_version():
         str: requirement string for setup_requires
     """
     require_str = "pyscaffold>={major}.{minor}a0,<{major}.{next_minor}a0"
-    major, minor, *rest = parse_version(pyscaffold_version).release
+    major, minor, *rest = (parse_version(pyscaffold_version)
+                           .base_version.split('.'))
     next_minor = int(minor) + 1
     return require_str.format(major=major, minor=minor, next_minor=next_minor)
 

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -1,0 +1,264 @@
+# -*- coding: utf-8 -*-
+"""
+Functionality to update one PyScaffold version to another
+"""
+import os
+from configparser import ConfigParser
+from distutils.version import LooseVersion
+from functools import reduce
+from os.path import exists as path_exists
+from os.path import join as join_path
+
+from . import __version__ as pyscaffold_version
+from .api import helpers
+from .contrib.configupdater import ConfigUpdater
+from .log import logger
+from .structure import FileOp
+
+
+def apply_update_rules(struct, opts, prefix=None):
+    """Apply update rules using :obj:`~.FileOp` to a directory structure.
+
+    As a result the filtered structure keeps only the files that actually will
+    be written.
+
+    Args:
+        opts (dict): options of the project, containing the following flags:
+
+            - **update**: when the project already exists and should be updated
+            - **force**: overwrite all the files that already exist
+
+        struct (dict): directory structure as dictionary of dictionaries
+            (in this tree representation, each leaf can be just a
+            string or a tuple also containing an update rule)
+        prefix (str): prefix path for the structure
+
+    Returns:
+        tuple(dict, dict):
+            directory structure with keys removed according to the rules
+            (in this tree representation, all the leaves are strings) and input
+            options
+    """
+    if prefix is None:
+        prefix = os.getcwd()
+
+    filtered = {}
+
+    for k, v in struct.items():
+        if isinstance(v, dict):
+            v, _ = apply_update_rules(v, opts, join_path(prefix, k))
+        else:
+            path = join_path(prefix, k)
+            v = apply_update_rule_to_file(path, v, opts)
+
+        if v:
+            filtered[k] = v
+
+    return filtered, opts
+
+
+def apply_update_rule_to_file(path, value, opts):
+    """Applies the update rule to a given file path
+
+    Args:
+        path (str): file path
+        value (tuple or str): content (and update rule)
+        opts (dict): options of the project, containing the following flags:
+
+            - **update**: if the project already exists and should be updated
+            - **force**: overwrite all the files that already exist
+
+    Returns:
+        content of the file if it should be generated or None otherwise.
+    """
+    if isinstance(value, (tuple, list)):
+        content, rule = value
+    else:
+        content, rule = value, None
+
+    update = opts.get('update')
+    force = opts.get('force')
+
+    skip = update and not force and (
+            rule == FileOp.NO_CREATE or
+            path_exists(path) and rule == FileOp.NO_OVERWRITE)
+
+    if skip:
+        logger.report('skip', path)
+        return None
+
+    return content
+
+
+def read_setupcfg(project_path):
+    """Reads-in setup.cfg for updating
+
+    Args:
+        project_path (str): path to project
+
+    Returns:
+
+    """
+    path = join_path(project_path, 'setup.cfg')
+    updater = ConfigUpdater()
+    updater.read(path)
+    return updater
+
+
+def get_curr_version(project_path):
+    """Retrieves the PyScaffold version that put up the scaffold
+
+    Args:
+        project_path: path to project
+
+    Returns:
+        LooseVersion: version specifier
+    """
+    setupcfg = ConfigParser()
+    setupcfg.read(join_path(project_path, 'setup.cfg'))
+    return LooseVersion(setupcfg['pyscaffold']['version'])
+
+
+def invoke_action(action, struct, opts):
+    """Invoke action with proper logging.
+
+    Args:
+        struct (dict): project representation as (possibly) nested
+            :obj:`dict`.
+        opts (dict): given options, see :obj:`create_project` for
+            an extensive list.
+
+    Returns:
+        tuple(dict, dict): updated project representation and options
+    """
+    logger.report('invoke', helpers.get_id(action))
+    with logger.indent():
+        struct, opts = action(struct, opts)
+
+    return struct, opts
+
+
+def version_migration(struct, opts):
+    """Migrations from one version to another
+
+    Args:
+        struct (dict): previous directory structure (ignored)
+        opts (dict): options of the project
+
+    Returns:
+        tuple(dict, dict):
+            structure as dictionary of dictionaries and input options
+    """
+    update = opts.get('update')
+
+    if not update:
+        return struct, opts
+
+    curr_version = get_curr_version(opts['project'])
+
+    # specify how to migrate from one version to another as ordered list
+    migration_plans = [
+        (LooseVersion('3.1'), [add_entrypoints,
+                               add_setup_requires])
+    ]
+    for plan_version, plan_actions in migration_plans:
+        if curr_version < plan_version:
+            struct, opts = reduce(lambda acc, f: invoke_action(f, *acc),
+                                  plan_actions, (struct, opts))
+
+    # note the updating version in setup.cfg for future use
+    update_pyscaffold_version(opts['project'])
+    return struct, opts
+
+
+def add_entrypoints(struct, opts):
+    """Add [options.entry_points] to setup.cfg
+
+    Args:
+        struct (dict): previous directory structure (ignored)
+        opts (dict): options of the project
+
+    Returns:
+        tuple(dict, dict):
+            structure as dictionary of dictionaries and input options
+    """
+    setupcfg = read_setupcfg(opts['project'])
+    section_str = """[options.entry_points]
+# Add here console scripts like:
+# console_scripts =
+#     script_name = ${package}.module:function
+# For example:
+# console_scripts =
+#     fibonacci = ${package}.skeleton:run
+# And any other entry points, for example:
+# pyscaffold.cli =
+#     awesome = pyscaffoldext.awesome.extension:AwesomeExtension
+    """
+    new_section_name = 'options.entry_points'
+    if new_section_name in setupcfg:
+        return
+
+    new_section = ConfigUpdater()
+    new_section.read_string(section_str)
+    new_section = new_section[new_section_name]
+
+    add_after_sect = 'options.extras_require'
+    if add_after_sect not in setupcfg:
+        # user removed it for some reason, default to metadata
+        add_after_sect = 'metadata'
+
+    setupcfg[add_after_sect].add_after.section(new_section).space()
+    setupcfg.update_file()
+    return struct, opts
+
+
+def get_setup_requires_version():
+    """Determines the proper `setup_requires` string for PyScaffold
+
+    E.g. setup_requires = pyscaffold>=3.0a0,<3.1a0
+
+    Returns:
+        str: requirement string for setup_requires
+    """
+    require_str = "pyscaffold>={major}.{minor}a0,<{major}.{next_minor}a0"
+    major, minor, *rest = LooseVersion(pyscaffold_version).version
+    next_minor = int(minor) + 1
+    return require_str.format(major=major, minor=minor, next_minor=next_minor)
+
+
+def add_setup_requires(struct, opts):
+    """Add `setup_requires` in setup.cfg
+
+    Args:
+        struct (dict): previous directory structure (ignored)
+        opts (dict): options of the project
+
+    Returns:
+        tuple(dict, dict):
+            structure as dictionary of dictionaries and input options
+    """
+    setupcfg = read_setupcfg(opts['project'])
+    comment = ("# DON'T CHANGE THE FOLLOWING LINE! "
+               "IT WILL BE UPDATED BY PYSCAFFOLD!")
+    options = setupcfg['options']
+    if 'setup_requires' in options:
+        return
+
+    version_str = get_setup_requires_version()
+    (options['package_dir'].add_after
+                           .comment(comment)
+                           .option('setup_requires', version_str))
+    setupcfg.update_file()
+    return struct, opts
+
+
+def update_pyscaffold_version(project_path):
+    """Update `setup_requires` in setup.cfg
+
+    Args:
+        project_path (str): path to project
+    """
+    setupcfg = read_setupcfg(project_path)
+    setupcfg['options']['setup_requires'] = get_setup_requires_version()
+    setupcfg['pyscaffold']['version'] = pyscaffold_version
+    setupcfg.update_file()

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -168,7 +168,7 @@ def version_migration(struct, opts):
                                   plan_actions, (struct, opts))
 
     # note the updating version in setup.cfg for future use
-    update_pyscaffold_version(opts['project'])
+    update_pyscaffold_version(opts['project'], opts['pretend'])
     # replace the old version with the updated one
     opts['version'] = pyscaffold_version
     return struct, opts
@@ -211,7 +211,8 @@ def add_entrypoints(struct, opts):
         add_after_sect = 'metadata'
 
     setupcfg[add_after_sect].add_after.section(new_section).space()
-    setupcfg.update_file()
+    if not opts['pretend']:
+        setupcfg.update_file()
     return struct, opts
 
 
@@ -251,17 +252,20 @@ def add_setup_requires(struct, opts):
     (options['package_dir'].add_after
                            .comment(comment)
                            .option('setup_requires', version_str))
-    setupcfg.update_file()
+    if not opts['pretend']:
+        setupcfg.update_file()
     return struct, opts
 
 
-def update_pyscaffold_version(project_path):
+def update_pyscaffold_version(project_path, pretend):
     """Update `setup_requires` in setup.cfg
 
     Args:
         project_path (str): path to project
+        pretend (bool): only pretend to do something
     """
     setupcfg = read_setupcfg(project_path)
     setupcfg['options']['setup_requires'] = get_setup_requires_version()
     setupcfg['pyscaffold']['version'] = pyscaffold_version
-    setupcfg.update_file()
+    if not pretend:
+        setupcfg.update_file()

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -10,10 +10,10 @@ from os.path import join as join_path
 from pkg_resources import parse_version
 
 from . import __version__ as pyscaffold_version
-from .api import helpers
 from .contrib.configupdater import ConfigUpdater
 from .log import logger
 from .structure import FileOp
+from .utils import get_id, get_setup_requires_version
 
 
 def apply_update_rules(struct, opts, prefix=None):
@@ -117,7 +117,7 @@ def invoke_action(action, struct, opts):
     Returns:
         tuple(dict, dict): updated project representation and options
     """
-    logger.report('invoke', helpers.get_id(action))
+    logger.report('invoke', get_id(action))
     with logger.indent():
         struct, opts = action(struct, opts)
 
@@ -134,7 +134,7 @@ def get_curr_version(project_path):
         Version: version specifier
     """
     setupcfg = read_setupcfg(project_path)
-    return parse_version(setupcfg['pyscaffold']['version'])
+    return parse_version(setupcfg['pyscaffold']['version'].value)
 
 
 def version_migration(struct, opts):
@@ -212,21 +212,6 @@ def add_entrypoints(struct, opts):
     if not opts['pretend']:
         setupcfg.update_file()
     return struct, opts
-
-
-def get_setup_requires_version():
-    """Determines the proper `setup_requires` string for PyScaffold
-
-    E.g. setup_requires = pyscaffold>=3.0a0,<3.1a0
-
-    Returns:
-        str: requirement string for setup_requires
-    """
-    require_str = "pyscaffold>={major}.{minor}a0,<{major}.{next_minor}a0"
-    major, minor, *rest = (parse_version(pyscaffold_version)
-                           .base_version.split('.'))
-    next_minor = int(minor) + 1
-    return require_str.format(major=major, minor=minor, next_minor=next_minor)
 
 
 def add_setup_requires(struct, opts):

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -3,7 +3,6 @@
 Functionality to update one PyScaffold version to another
 """
 import os
-from configparser import ConfigParser
 from functools import reduce
 from os.path import exists as path_exists
 from os.path import join as join_path
@@ -134,8 +133,7 @@ def get_curr_version(project_path):
     Returns:
         Version: version specifier
     """
-    setupcfg = ConfigParser()
-    setupcfg.read(join_path(project_path, 'setup.cfg'))
+    setupcfg = read_setupcfg(project_path)
     return parse_version(setupcfg['pyscaffold']['version'])
 
 

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -243,12 +243,12 @@ def check_setuptools_version():
           :obj:`OldSetuptools` : raised if necessary capabilities are not met
     """
     try:
-        from distutils.version import LooseVersion
         from setuptools import __version__ as setuptools_ver
+        from packaging.version import parse as parse_version
     except ImportError:
         raise OldSetuptools
 
-    setuptools_too_old = LooseVersion(setuptools_ver) < LooseVersion('31')
+    setuptools_too_old = parse_version(setuptools_ver) < parse_version('31')
     setuptools_scm_check_failed = VERSION_CLASS is None
     if setuptools_too_old or setuptools_scm_check_failed:
         raise OldSetuptools

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -11,6 +11,9 @@ import shutil
 import sys
 from contextlib import contextmanager
 
+from pkg_resources import parse_version
+
+from . import __version__ as pyscaffold_version
 from .contrib.setuptools_scm.version import VERSION_CLASS
 from .exceptions import InvalidIdentifier, OldSetuptools
 from .log import logger
@@ -295,3 +298,38 @@ def dasherize(word):
         input word with underscores replaced by dashes
     """
     return word.replace('_', '-')
+
+
+def get_id(function):
+    """Given a function, calculate its identifier.
+
+    A identifier is a string in the format ``<module name>:<function name>``,
+    similarly to the convention used for setuptools entry points.
+
+    Note:
+        This function does not return a Python 3 ``__qualname__`` equivalent.
+        If the function is nested inside another function or class, the parent
+        name is ignored.
+
+    Args:
+        function (callable): function object
+
+    Returns:
+        str: identifier
+    """
+    return '{}:{}'.format(function.__module__, function.__name__)
+
+
+def get_setup_requires_version():
+    """Determines the proper `setup_requires` string for PyScaffold
+
+    E.g. setup_requires = pyscaffold>=3.0a0,<3.1a0
+
+    Returns:
+        str: requirement string for setup_requires
+    """
+    require_str = "pyscaffold>={major}.{minor}a0,<{major}.{next_minor}a0"
+    major, minor, *rest = (parse_version(pyscaffold_version)
+                           .base_version.split('.'))
+    next_minor = int(minor) + 1
+    return require_str.format(major=major, minor=minor, next_minor=next_minor)

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -244,7 +244,7 @@ def check_setuptools_version():
     """
     try:
         from setuptools import __version__ as setuptools_ver
-        from packaging.version import parse as parse_version
+        from pkg_resources import parse_version
     except ImportError:
         raise OldSetuptools
 

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -125,31 +125,6 @@ def make_valid_identifier(string):
                 "String cannot be converted to a valid identifier.")
 
 
-def list2str(lst, indent=0, brackets=True, quotes=True, sep=','):
-    """Generate a Python syntax list string with an indention
-
-    Args:
-        lst ([str]): list of strings
-        indent (int): indention
-        brackets (bool): surround the list expression by brackets
-        quotes (bool): surround each item with quotes
-        sep (str): separator for each item
-
-    Returns:
-        str: string representation of the list
-    """
-    if quotes:
-        lst_str = str(lst)
-        if not brackets:
-            lst_str = lst_str[1:-1]
-    else:
-        lst_str = ', '.join(lst)
-        if brackets:
-            lst_str = '[' + lst_str + ']'
-    lb = '{}\n'.format(sep) + indent*' '
-    return lst_str.replace(', ', lb)
-
-
 def exceptions2exit(exception_list):
     """Decorator to convert given exceptions to exit messages
 

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -10,12 +10,10 @@ import re
 import shutil
 import sys
 from contextlib import contextmanager
-from operator import itemgetter
 
 from .contrib.setuptools_scm.version import VERSION_CLASS
 from .exceptions import InvalidIdentifier, OldSetuptools
 from .log import logger
-from .templates import licenses
 
 
 @contextmanager
@@ -198,19 +196,6 @@ def levenshtein(s1, s2):
         previous_row = current_row
 
     return previous_row[-1]
-
-
-def best_fit_license(txt):
-    """Finds proper license name for the license defined in txt
-
-    Args:
-        txt (str): license name
-
-    Returns:
-        str: license name
-    """
-    ratings = {lic: levenshtein(txt, lic.lower()) for lic in licenses}
-    return min(ratings.items(), key=itemgetter(1))[0]
 
 
 def prepare_namespace(namespace_str):

--- a/tests/api/test_helpers.py
+++ b/tests/api/test_helpers.py
@@ -125,7 +125,7 @@ def test_reject_without_file():
 
 
 def custom_action(structure, options):
-    return (structure, options)
+    return structure, options
 
 
 custom_action.__module__ = 'awesome_module'
@@ -133,11 +133,7 @@ custom_action.__module__ = 'awesome_module'
 
 def init_git(structure, options):
     """Fake action that shares the same name as a default action."""
-    return (structure, options)
-
-
-def test_get_id():
-    assert helpers.get_id(custom_action) == 'awesome_module:custom_action'
+    return structure, options
 
 
 def test_register_before():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import builtins
 import logging
 import os
 import shlex
@@ -18,14 +19,6 @@ import pytest
 
 from .helpers import uniqstr
 
-try:
-    # First try python 2.7.x
-    # (for some recent versions the `builtins` module is available,
-    # but it behaves differently from the one in 3.x)
-    import __builtin__ as builtins
-except ImportError:
-    import builtins
-
 
 def nop(*args, **kwargs):
     """Function that does nothing"""
@@ -42,7 +35,7 @@ def set_writable(func, path, exc_info):
         os.chmod(path, stat.S_IWUSR)
         func(path)
     else:
-        raise
+        raise RuntimeError
 
 
 def command_exception(content):
@@ -55,7 +48,7 @@ def command_exception(content):
 
 @pytest.fixture
 def venv(virtualenv):
-    """Create a virutalenv for each test"""
+    """Create a virtualenv for each test"""
     return virtualenv
 
 

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -165,3 +165,16 @@ def test_namespace_cookiecutter(cwd):
     # and all the common tasks should run properly
     with cwd.join('myproj').as_cwd():
         run_common_tasks(flake8=False, tests=False)
+
+
+def putup_version():
+    return tuple(run('putup --version').split()[1].split('.')[:2])
+
+
+def test_update_version_3_0_to_3_1(cwd):
+    run("pip install 'pyscaffold>=3.0<3.1'")
+    assert putup_version() == (3, 0)
+    run('putup my_old_proj')
+    run("pip uninstall -y pyscaffold")
+    assert putup_version() > (3, 0)
+    run('putup --update my_old_proj')

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -165,16 +165,3 @@ def test_namespace_cookiecutter(cwd):
     # and all the common tasks should run properly
     with cwd.join('myproj').as_cwd():
         run_common_tasks(flake8=False, tests=False)
-
-
-def putup_version():
-    return tuple(run('putup --version').split()[1].split('.')[:2])
-
-
-def test_update_version_3_0_to_3_1(cwd):
-    run("pip install 'pyscaffold>=3.0<3.1'")
-    assert putup_version() == (3, 0)
-    run('putup my_old_proj')
-    run("pip uninstall -y pyscaffold")
-    assert putup_version() > (3, 0)
-    run('putup --update my_old_proj')

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -7,7 +7,7 @@ import socket
 
 import pytest
 
-from pyscaffold import cli, exceptions, info
+from pyscaffold import cli, exceptions, info, templates
 
 
 def test_username_with_git(git_mock):
@@ -113,3 +113,10 @@ def test_project_with_wrong_setup(tmpfolder):
     args = cli.parse_args(args)
     with pytest.raises(RuntimeError):
         info.project(args)
+
+
+def test_best_fit_license():
+    txt = "new_bsd"
+    assert info.best_fit_license(txt) == "new-bsd"
+    for license in templates.licenses.keys():
+        assert info.best_fit_license(license) == license

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -118,7 +118,7 @@ class DemoApp(object):
 
     def run(self, *args, **kwargs):
         # pytest-virtualenv doesn't play nicely with external os.chdir
-        # so let's be explicity about it...
+        # so let's be explicit about it...
         kwargs['cd'] = os.getcwd()
         kwargs['capture'] = True
         return self.venv.run(args, **kwargs).strip()

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 
-from pyscaffold import api, cli, repo, shell, structure, utils
+from pyscaffold import api, cli, repo, shell, structure, utils, update
 
 
 def test_init_commit_repo(tmpfolder):
@@ -67,7 +67,7 @@ def test_version_of_subdir(tmpfolder):
         opts = cli.parse_args([project])
         _, opts = api.get_default_options({}, opts)
         struct, _ = structure.define_structure({}, opts)
-        struct, _ = structure.apply_update_rules(struct, opts)
+        struct, _ = update.apply_update_rules(struct, opts)
         structure.create_structure(struct, {})
         repo.init_commit_repo(project, struct)
     shutil.rmtree(os.path.join('inner_project', '.git'))

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 
-from pyscaffold import api, cli, repo, shell, structure, utils, update
+from pyscaffold import api, cli, repo, shell, structure, update, utils
 
 
 def test_init_commit_repo(tmpfolder):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import logging
 import os
-import re
 from os.path import isdir, isfile
 
 import pytest
 
 from pyscaffold import api, cli, structure
-
-from .helpers import uniqstr
 
 
 def test_create_structure(tmpfolder):
@@ -72,60 +68,3 @@ def test_define_structure():
     _, opts = api.get_default_options({}, opts)
     struct, _ = structure.define_structure({}, opts)
     assert isinstance(struct, dict)
-
-
-def test_apply_update_rules_to_file(tmpfolder, caplog):
-    caplog.set_level(logging.INFO)
-    NO_OVERWRITE = structure.FileOp.NO_OVERWRITE
-    NO_CREATE = structure.FileOp.NO_CREATE
-
-    # When update is False (no project exists yet) always update
-    opts = {"update": False}
-    res = structure.apply_update_rule_to_file("a", ("a", NO_CREATE), opts)
-    assert res == "a"
-    # When content is string always update
-    opts = {"update": True}
-    res = structure.apply_update_rule_to_file("a", "a", opts)
-    assert res == "a"
-    # When force is True always update
-    opts = {"update": True, "force": True}
-    res = structure.apply_update_rule_to_file("a", ("a", NO_CREATE), opts)
-    assert res == "a"
-    # When file exist, update is True, rule is NO_OVERWRITE, do nothing
-    opts = {"update": True}
-    fname = uniqstr()
-    tmpfolder.join(fname).write("content")
-    res = structure.apply_update_rule_to_file(
-        fname, (fname, NO_OVERWRITE), opts)
-    assert res is None
-    logs = caplog.text
-    assert re.search("skip.*" + fname, logs)
-    # When file does not exist, update is True, but rule is NO_CREATE, do
-    # nothing
-    opts = {"update": True}
-    fname = uniqstr()
-    res = structure.apply_update_rule_to_file(fname, (fname, NO_CREATE), opts)
-    assert res is None
-    assert re.search("skip.*" + fname, caplog.text)
-
-
-def test_apply_update_rules(tmpfolder):
-    NO_OVERWRITE = structure.FileOp.NO_OVERWRITE
-    NO_CREATE = structure.FileOp.NO_CREATE
-    opts = dict(update=True)
-
-    struct = {"a": ("a", NO_OVERWRITE),
-              "b": "b",
-              "c": {"a": "a",
-                    "b": ("b", NO_OVERWRITE)},
-              "d": {"a": ("a", NO_OVERWRITE),
-                    "b": ("b", NO_CREATE)},
-              "e": ("e", NO_CREATE)}
-    dir_struct = {"a": "a",
-                  "c": {"b": "b"}}
-    exp_struct = {"b": "b",
-                  "c": {"a": "a"},
-                  "d": {"a": "a"}}
-    structure.create_structure(dir_struct, opts)
-    res_struct, _ = structure.apply_update_rules(struct, opts)
-    assert res_struct == exp_struct

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import logging
+import re
+
+from pyscaffold import structure, update
+
+from .helpers import uniqstr
+
+
+def test_apply_update_rules_to_file(tmpfolder, caplog):
+    caplog.set_level(logging.INFO)
+    NO_OVERWRITE = structure.FileOp.NO_OVERWRITE
+    NO_CREATE = structure.FileOp.NO_CREATE
+
+    # When update is False (no project exists yet) always update
+    opts = {"update": False}
+    res = update.apply_update_rule_to_file("a", ("a", NO_CREATE), opts)
+    assert res == "a"
+    # When content is string always update
+    opts = {"update": True}
+    res = update.apply_update_rule_to_file("a", "a", opts)
+    assert res == "a"
+    # When force is True always update
+    opts = {"update": True, "force": True}
+    res = update.apply_update_rule_to_file("a", ("a", NO_CREATE), opts)
+    assert res == "a"
+    # When file exist, update is True, rule is NO_OVERWRITE, do nothing
+    opts = {"update": True}
+    fname = uniqstr()
+    tmpfolder.join(fname).write("content")
+    res = update.apply_update_rule_to_file(
+        fname, (fname, NO_OVERWRITE), opts)
+    assert res is None
+    logs = caplog.text
+    assert re.search("skip.*" + fname, logs)
+    # When file does not exist, update is True, but rule is NO_CREATE, do
+    # nothing
+    opts = {"update": True}
+    fname = uniqstr()
+    res = update.apply_update_rule_to_file(fname, (fname, NO_CREATE), opts)
+    assert res is None
+    assert re.search("skip.*" + fname, caplog.text)
+
+
+def test_apply_update_rules(tmpfolder):
+    NO_OVERWRITE = structure.FileOp.NO_OVERWRITE
+    NO_CREATE = structure.FileOp.NO_CREATE
+    opts = dict(update=True)
+
+    struct = {"a": ("a", NO_OVERWRITE),
+              "b": "b",
+              "c": {"a": "a",
+                    "b": ("b", NO_OVERWRITE)},
+              "d": {"a": ("a", NO_OVERWRITE),
+                    "b": ("b", NO_CREATE)},
+              "e": ("e", NO_CREATE)}
+    dir_struct = {"a": "a",
+                  "c": {"b": "b"}}
+    exp_struct = {"b": "b",
+                  "c": {"a": "a"},
+                  "d": {"a": "a"}}
+    structure.create_structure(dir_struct, opts)
+    res_struct, _ = update.apply_update_rules(struct, opts)
+    assert res_struct == exp_struct

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,8 +2,14 @@
 # -*- coding: utf-8 -*-
 import logging
 import re
+from os.path import join as path_join
 
-from pyscaffold import structure, update
+from pkg_resources import parse_version, working_set
+
+import pytest
+
+from pyscaffold import __version__, structure, update
+from pyscaffold.utils import chdir
 
 from .helpers import uniqstr
 
@@ -63,3 +69,95 @@ def test_apply_update_rules(tmpfolder):
     structure.create_structure(dir_struct, opts)
     res_struct, _ = update.apply_update_rules(struct, opts)
     assert res_struct == exp_struct
+
+
+class VenvManager(object):
+    def __init__(self, tmpdir, venv, pytestconfig):
+        self.tmpdir = str(tmpdir)  # convert Path to str
+        self.installed = False
+        self.venv = venv
+        self.venv_path = str(venv.virtualenv)
+        self.pytestconfig = pytestconfig
+        self.venv.install_package("install coverage", installer='pip')
+
+    def install_this_pyscaffold(self):
+        # Normally the following command should do the trick
+        # self.venv.install_package('PyScaffold')
+        # but sadly pytest-virtualenv chokes on the src-layout of PyScaffold
+        installed = [p for p in working_set if p.project_name == 'PyScaffold']
+        assert installed, 'Install PyScaffold with python setup.py develop!'
+        # ToDo: The following will fail on Windows...
+        src_dir = path_join(installed[0].location, '..')
+        cmd = "cd {src_dir}; {python} setup.py -q develop".format(
+            src_dir=src_dir, python=self.venv.python
+        )
+        self.run(cmd)
+        assert __version__ == str(self.pyscaffold_version())
+        self.installed = True
+        return self
+
+    def install_pyscaffold(self, major, minor):
+        ver = "pyscaffold>={major}.{minor}<{major}.{next_minor}".format(
+            major=major, minor=minor, next_minor=minor + 1)
+        self.venv.install_package("install '{}'".format(ver),
+                                  installer='pip')
+        installed_version = self.pyscaffold_version()._version.release[:2]
+        assert installed_version == (major, minor)
+        self.installed = True
+        return self
+
+    def uninstall_pyscaffold(self):
+        self.run('pip uninstall -y pyscaffold')
+        assert 'PyScaffold' not in self.venv.installed_packages().keys()
+        self.installed = False
+        return self
+
+    def pyscaffold_version(self):
+        version = self.venv.installed_packages().get('PyScaffold', None)
+        if version:
+            return parse_version(version.version)
+        else:
+            return None
+
+    def putup(self, *args, with_coverage=False, **kwargs):
+        if with_coverage:
+            # need to pass here as list since its args to coverage.py
+            args = [subarg for arg in args for subarg in arg.split()]
+            cmd = ['-m', 'pyscaffold.cli'] + args
+        else:
+            # need to pass here as string since it's the cmd itself
+            cmd = ' '.join(['putup'] + list(args))
+        self.run(cmd, with_coverage=with_coverage, **kwargs)
+        return self
+
+    def run(self, cmd, with_coverage=False, **kwargs):
+        # pytest-virtualenv doesn't play nicely with external os.chdir
+        # so let's be explicit about it...
+        kwargs['cd'] = self.tmpdir
+        kwargs['cwd'] = self.tmpdir
+        with chdir(self.tmpdir):
+            if with_coverage:
+                kwargs['pytestconfig'] = self.pytestconfig
+                return self.venv.run_with_coverage(cmd, **kwargs).strip()
+            else:
+                return self.venv.run(cmd, capture=True, **kwargs).strip()
+
+    def get_file(self, path):
+        return self.run('cat {}'.format(path))
+
+
+@pytest.fixture
+def venv_mgr(tmpfolder, venv, pytestconfig):
+    return VenvManager(tmpfolder, venv, pytestconfig)
+
+
+def test_update_version_3_0_to_3_1(venv_mgr):
+    (venv_mgr.install_pyscaffold(3, 0)
+             .putup('my_old_project')
+             .uninstall_pyscaffold()
+             .install_this_pyscaffold()
+             .putup('--update my_old_project', with_coverage=True))
+    # from IPython import embed; embed()
+    setup_cfg = venv_mgr.get_file(path_join('my_old_project', 'setup.cfg'))
+    assert '[options.entry_points]' in setup_cfg
+    assert 'setup_requires' in setup_cfg

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -79,6 +79,7 @@ class VenvManager(object):
         self.venv = venv
         self.venv_path = str(venv.virtualenv)
         self.pytestconfig = pytestconfig
+        self.orig_dir = os.getcwd()
         self.venv.install_package("install coverage", installer='pip')
 
     def install_this_pyscaffold(self):
@@ -139,10 +140,10 @@ class VenvManager(object):
     def run(self, cmd, with_coverage=False, **kwargs):
         # pytest-virtualenv doesn't play nicely with external os.chdir
         # so let's be explicit about it...
-        kwargs.setdefault('cd', self.tmpdir)
         kwargs.setdefault('cwd', self.tmpdir)
         with chdir(self.tmpdir):
             if with_coverage:
+                kwargs.setdefault('cd', self.orig_dir)
                 kwargs.setdefault('pytestconfig', self.pytestconfig)
                 return self.venv.run_with_coverage(cmd, **kwargs).strip()
             else:
@@ -166,3 +167,14 @@ def test_update_version_3_0_to_3_1(venv_mgr):
     setup_cfg = venv_mgr.get_file(path_join('my_old_project', 'setup.cfg'))
     assert '[options.entry_points]' in setup_cfg
     assert 'setup_requires' in setup_cfg
+
+
+def test_update_version_3_0_to_3_1_pretend(venv_mgr):
+    (venv_mgr.install_pyscaffold(3, 0)
+             .putup('my_old_project')
+             .uninstall_pyscaffold()
+             .install_this_pyscaffold()
+             .putup('--pretend --update my_old_project', with_coverage=True))
+    setup_cfg = venv_mgr.get_file(path_join('my_old_project', 'setup.cfg'))
+    assert '[options.entry_points]' not in setup_cfg
+    assert 'setup_requires' not in setup_cfg

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -257,3 +257,11 @@ def test_pretend_move(tmpfolder):
     # Then the src should not be moved
     assert not tmpfolder.join('a-dir/another-file.txt').check()
     assert tmpfolder.join('another-file.txt').check()
+
+
+def test_get_id():
+    def custom_action(structure, options):
+        return structure, options
+
+    custom_action.__module__ = 'awesome_module'
+    assert utils.get_id(custom_action) == 'awesome_module:custom_action'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import re
 
 import pytest
 
-from pyscaffold import templates, utils
+from pyscaffold import utils
 from pyscaffold.exceptions import InvalidIdentifier
 
 from .helpers import uniqstr
@@ -112,13 +112,6 @@ def test_prepare_namespace():
     assert namespaces == ["com", "com.blue_yonder"]
     with pytest.raises(InvalidIdentifier):
         utils.prepare_namespace("com.blue-yonder")
-
-
-def test_best_fit_license():
-    txt = "new_bsd"
-    assert utils.best_fit_license(txt) == "new-bsd"
-    for license in templates.licenses.keys():
-        assert utils.best_fit_license(license) == license
 
 
 def test_create_file(tmpfolder):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,29 +63,6 @@ def test_make_valid_identifier():
         utils.make_valid_identifier("def")
 
 
-def test_list2str():
-    classifiers = ['Development Status :: 4 - Beta',
-                   'Programming Language :: Python']
-    class_str = utils.list2str(classifiers, indent=len("classifiers = ") + 1)
-    exp_class_str = """\
-['Development Status :: 4 - Beta',
-               'Programming Language :: Python']"""
-    assert class_str == exp_class_str
-    classifiers = ['Development Status :: 4 - Beta']
-    class_str = utils.list2str(classifiers, indent=len("classifiers = ") + 1)
-    assert class_str == "['Development Status :: 4 - Beta']"
-    classifiers = []
-    class_str = utils.list2str(classifiers, indent=len("classifiers = ") + 1)
-    assert class_str == "[]"
-    classifiers = ['Development Status :: 4 - Beta']
-    class_str = utils.list2str(classifiers, brackets=False)
-    assert class_str == "'Development Status :: 4 - Beta'"
-    class_str = utils.list2str(classifiers, brackets=False, quotes=False)
-    assert class_str == "Development Status :: 4 - Beta"
-    class_str = utils.list2str(classifiers, brackets=True, quotes=False)
-    assert class_str == "[Development Status :: 4 - Beta]"
-
-
 def test_exceptions2exit():
     @utils.exceptions2exit([RuntimeError])
     def func(_):

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -7,7 +7,7 @@
 # This script is inspired by Scikit-Learn (http://scikit-learn.org/)
 #
 
-set -e
+set -e -x
 
 if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     brew outdated || brew update
@@ -76,10 +76,10 @@ else
 fi
 
 # for all
-pip install -U pip setuptools
 pip install sphinx
 pip install cookiecutter
 pip install tox
+pip install -U pip setuptools
 
 travis-cleanup() {
     printf "Cleaning up environments ... "  # printf avoids new lines

--- a/tests/travis_install.sh
+++ b/tests/travis_install.sh
@@ -7,7 +7,7 @@
 # This script is inspired by Scikit-Learn (http://scikit-learn.org/)
 #
 
-set -e -x
+set -e
 
 if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     brew outdated || brew update

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ minversion = 2.4
 envlist = default
 
 [testenv]
+setenv = TOXINIDIR = {toxinidir}
 passenv =
     HOME
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ passenv =
 commands =
     default: py.test -k "not system" {posargs}
     system: py.test -k system {posargs}
-    all: py.test {posargs}
+    all: py.test -vv {posargs}
 extras =
     all
     testing


### PR DESCRIPTION
This PR is a proposal how to do the updating from one PyScaffold version to another with a focus on `setup.cfg`. It thus also addresses #139 since it uses [configupdater](https://github.com/pyscaffold/configupdater) to accomplish all this. I haven't yet created any additional unit tests to avoid any unnecessary work if this is a dead end but so far my local tests look quite good and it does what it is intended to do. 
@abravalheri What do you think about this approach?