### PR TITLE
Fix update external generators

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -94,6 +94,10 @@ Clone the repository
    number of processes slightly bigger than the available number of CPUs is a
    good idea.
 
+   If you find any error related to versions in ``test_update.py`` when
+   executing the tests, try to run ``python setup.py egg_info --egg-base .``
+   again (or ``tox -e build`` if you are using ``tox``)
+
 #. Use `flake8`_ to check your code style.
 #. Add yourself to the list of contributors in ``AUTHORS.rst``.
 #. Go to the web page of your PyScaffold fork, and click

--- a/src/pyscaffold/extensions/cookiecutter.py
+++ b/src/pyscaffold/extensions/cookiecutter.py
@@ -7,6 +7,7 @@ import argparse
 
 from ..api import Extension
 from ..api.helpers import logger, register
+from ..warnings import UpdateNotSupported
 
 
 class Cookiecutter(Extension):
@@ -92,9 +93,6 @@ def enforce_cookiecutter_options(struct, opts):
     Returns:
         struct, opts: updated project representation and options
     """
-    if opts.get('update'):
-        raise UpdateNotSupported
-
     opts['force'] = True
 
     return struct, opts
@@ -112,6 +110,10 @@ def create_cookiecutter(struct, opts):
     Returns:
         struct, opts: updated project representation and options
     """
+    if opts.get('update'):
+        logger.warning(UpdateNotSupported(extension='cookiecutter'))
+        return struct, opts
+
     try:
         from cookiecutter.main import cookiecutter
     except Exception as e:
@@ -157,15 +159,3 @@ class MissingTemplate(RuntimeError):
 
     def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
         super(MissingTemplate, self).__init__(message, *args, **kwargs)
-
-
-class UpdateNotSupported(RuntimeError):
-    """Cookiecutter is currently not able to do updates.
-    It fails if the directory already exists.
-    """
-
-    DEFAULT_MESSAGE = ("Updates are not supported when using the "
-                       "Cookiecutter extension")
-
-    def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
-        super(UpdateNotSupported, self).__init__(message, *args, **kwargs)

--- a/src/pyscaffold/extensions/django.py
+++ b/src/pyscaffold/extensions/django.py
@@ -5,6 +5,7 @@ Extension that creates a base structure for the project using django-admin.py.
 
 from .. import shell
 from ..api import Extension, helpers
+from ..warnings import UpdateNotSupported
 
 
 class Django(Extension):
@@ -67,6 +68,10 @@ def create_django_proj(struct, opts):
     Raises:
         :obj:`RuntimeError`: raised if django-admin.py is not installed
     """
+    if opts.get('update'):
+        helpers.logger.warning(UpdateNotSupported(extension='django'))
+        return struct, opts
+
     try:
         shell.django_admin('--version')
     except Exception as e:

--- a/src/pyscaffold/warnings.py
+++ b/src/pyscaffold/warnings.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""
+Warnings used by PyScaffold to identify issues that can be safely ignored
+but that should be displayed to the user.
+"""
+
+
+class UpdateNotSupported(RuntimeWarning):
+    """Extensions that make use of external generators are not able to do
+    updates by default.
+    """
+
+    DEFAULT_MESSAGE = ('Updating code generated using external tools is not '
+                       'supported. The extension `{}` will be ignored, only '
+                       'changes in PyScaffold core features will take place.')
+
+    def __init__(self, *args, extension=None, **kwargs):
+        if not args:
+            args = [self.DEFAULT_MESSAGE.format(extension)]
+        super(UpdateNotSupported, self).__init__(*args, **kwargs)

--- a/tests/extensions/test_cookiecutter.py
+++ b/tests/extensions/test_cookiecutter.py
@@ -92,7 +92,7 @@ def test_create_project_no_cookiecutter(tmpfolder, nocookiecutter_mock):
         create_project(opts)
 
 
-def test_create_project_cookiecutter_and_update(tmpfolder):
+def test_create_project_cookiecutter_and_update(tmpfolder, capsys):
     # Given a project exists
     create_project(project=PROJ_NAME)
 
@@ -102,10 +102,12 @@ def test_create_project_cookiecutter_and_update(tmpfolder):
                 update=True,
                 cookiecutter=COOKIECUTTER_URL,
                 extensions=[cookiecutter.Cookiecutter('cookiecutter')])
+    create_project(opts)
 
-    # then an exception should be raised.
-    with pytest.raises(cookiecutter.UpdateNotSupported):
-        create_project(opts)
+    # then a warning should be displayed
+    out, err = capsys.readouterr()
+    assert all(warn in out + err for warn in (
+        'external tools', 'not supported', 'will be ignored'))
 
 
 @pytest.mark.slow
@@ -156,11 +158,9 @@ def test_cli_with_cookiecutter_and_update(tmpfolder, capsys):
     # with the cookiecutter extension,
     sys.argv = ["pyscaffold", PROJ_NAME, "--update",
                 "--cookiecutter", COOKIECUTTER_URL]
+    run()
 
-    # then an exception should be raised.
-    with pytest.raises(SystemExit):
-        run()
-
-    # and the message says something relevant
+    # then a warning should be displayed
     out, err = capsys.readouterr()
-    assert "Updates are not supported" in out + err
+    assert all(warn in out + err for warn in (
+        'external tools', 'not supported', 'will be ignored'))

--- a/tests/extensions/test_django.py
+++ b/tests/extensions/test_django.py
@@ -101,3 +101,18 @@ def test_cli_without_django(tmpfolder):
     # then django files should not exist
     for path in DJANGO_FILES:
         assert not path_exists(path)
+
+
+def test_cli_with_django_and_update(tmpfolder, capsys):
+    # Given a project exists
+    create_project(project=PROJ_NAME)
+
+    # when the project is updated
+    # with the django extension,
+    sys.argv = ["pyscaffold", PROJ_NAME, "--update", "--django"]
+    run()
+
+    # then a warning should be displayed
+    out, err = capsys.readouterr()
+    assert all(warn in out + err for warn in (
+        'external tools', 'not supported', 'will be ignored'))

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -98,7 +98,7 @@ class VenvManager(object):
 
         cmd = "{python} setup.py -q develop".format(python=self.venv.python)
         self.run(cmd, cwd=src_dir)
-        assert __version__ == str(self.pyscaffold_version())
+        assert __version__ in str(self.pyscaffold_version())
         self.installed = True
         return self
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,12 @@
 
 [tox]
 minversion = 2.4
-envlist = default
+envlist = build, default
+
+[testenv:build]
+skip_install = true
+commands = python setup.py egg_info --egg-base {toxinidir}
+
 
 [testenv]
 setenv = TOXINIDIR = {toxinidir}


### PR DESCRIPTION
Previously, the cookiecutter externsion was raising an exception for every attempt of `--update`, which is not nice now that we have built-in support for version update.

This PR fix this behavior, by ignoring the extension and just displaying a warning to the user instead.
The django extension was changed accordingly.

Additionally, there is a workaround for #197.