### PR TITLE
Polish solution presented for #197

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -94,10 +94,6 @@ Clone the repository
    number of processes slightly bigger than the available number of CPUs is a
    good idea.
 
-   If you find any error related to versions in ``test_update.py`` when
-   executing the tests, try to run ``python setup.py egg_info --egg-base .``
-   again (or ``tox -e build`` if you are using ``tox``)
-
 #. Use `flake8`_ to check your code style.
 #. Add yourself to the list of contributors in ``AUTHORS.rst``.
 #. Go to the web page of your PyScaffold fork, and click
@@ -130,3 +126,12 @@ As a PyScaffold maintainer following steps are needed to release a new version:
 .. _creating a PR: https://help.github.com/articles/creating-a-pull-request/
 .. _tox: https://tox.readthedocs.io/
 .. _flake8: http://flake8.pycqa.org/
+
+Troubleshooting
+===============
+
+    I've got an strange error related to versions in ``test_update.py`` when
+    executing the test suite.
+
+Try to remove all the egg files, specially the one under ``src`` and
+run ``python setup.py egg_info --egg-base .`` again.

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -99,7 +99,7 @@ class VenvManager(object):
 
         cmd = "{python} setup.py -q develop".format(python=self.venv.python)
         self.run(cmd, cwd=src_dir)
-        assert self.running_version.public == self.pyscaffold_version().public
+        assert self.running_version.public <= self.pyscaffold_version().public
         self.installed = True
         return self
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 minversion = 2.4
-envlist = build, default
+envlist = default
 
 [testenv]
 setenv = TOXINIDIR = {toxinidir}


### PR DESCRIPTION
This PR relates to the on-going discussion on #197 

- Removes undefined testenv in tox.ini
- Includes a troubleshooting section in `CONTRIBUTING.rst`
- Change the comparison in `test_update` from `==` to `<=`
- Adds an assert that makes sure PyScaffold was installed from source in a editable mode, instead of PyPI

