### PR TITLE
Add deprecation notices about cookiecutter and django

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -183,6 +183,13 @@ PyScaffold comes with several extensions:
 
 There is also documentation about :ref:`writing extensions <extensions>`.
 
+.. warning:: *Deprecation Notice*
+    In the next major release both Cookiecutter and Django extensions
+    will be extracted into independent packages.
+    After PyScaffold v4.0, you will need to explicitly install
+    ``pyscaffoldext-cookiecutter`` and ``pyscaffoldext-django`` in your
+    system/virtualenv in order to be able to use them.
+
 Easy Updating
 =============
 

--- a/src/pyscaffold/extensions/cookiecutter.py
+++ b/src/pyscaffold/extensions/cookiecutter.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 """
 Extension that integrates cookiecutter templates into PyScaffold.
+
+Warning:
+    *Deprecation Notice* - In the next major release the Cookiecutter extension
+    will be extracted into an independent package.
+    After PyScaffold v4.0, you will need to explicitly install
+    ``pyscaffoldext-cookiecutter`` in your system/virtualenv in order to be
+    able to use it.
 """
 
 import argparse

--- a/src/pyscaffold/extensions/django.py
+++ b/src/pyscaffold/extensions/django.py
@@ -1,6 +1,13 @@
 # -*- coding: utf-8 -*-
 """
 Extension that creates a base structure for the project using django-admin.py.
+
+Warning:
+    *Deprecation Notice* - In the next major release the Django extension
+    will be extracted into an independent package.
+    After PyScaffold v4.0, you will need to explicitly install
+    ``pyscaffoldext-django`` in your system/virtualenv in order to be
+    able to use it.
 """
 import os
 import shutil


### PR DESCRIPTION
As discussed in #175 we should include a deprecation notice, so the users are aware in future changes in the interface.