### PR TITLE
Use pathlib in helpers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Version 3.1, 2018-08-22
 - *experimental* extension for MarkDown usage in README, issue #163
 - *experimental* support for Pipenv, issue #140
 - *deprecated* built-in Cookiecutter and Django extensions (to be moved to separated packages), issue #175
+- *deprecated* use of lists with ``helpers.{modify,ensure,reject}``, issue #211
 
 Version 2.5.11, 2018-04-14
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Version 3.1, 2018-08-22
 - *experimental* support for Pipenv, issue #140
 - *deprecated* built-in Cookiecutter and Django extensions (to be moved to separated packages), issue #175
 - *deprecated* use of lists with ``helpers.{modify,ensure,reject}``, issue #211
+- Add support for ``os.PathLike`` objects in ``helpers.{modify,ensure,reject}``, issue #211
 
 Version 2.5.11, 2018-04-14
 --------------------------

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -261,6 +261,8 @@ extension which defines the ``define_awesome_files`` action:
 
 .. code-block:: python
 
+    from pathlib import PurePath
+
     from ..api import Extension
     from ..api import helpers
 
@@ -309,7 +311,8 @@ extension which defines the ``define_awesome_files`` action:
 
             for filename in ['awesome_file1', 'awesome_file2']:
                 struct = helpers.ensure(
-                    struct, [opts['project'], 'src', 'awesome', filename],
+                    struct,
+                    PurePath(opts['project'], 'src', 'awesome', filename),
                     content='AWESOME!', update_rule=helpers.NO_CREATE)
                     # The second argument is the file path, represented by a
                     # list of file parts or a string.
@@ -326,7 +329,7 @@ extension which defines the ``define_awesome_files`` action:
             # `modify` can be used to change contents in an existing file
             struct = helpers.modify(
                 struct,
-                [opts['project'], 'tests', 'awesome_test.py'],
+                PurePath(opts['project'], 'tests', 'awesome_test.py'),
                 lambda content: 'import pdb\n' + content)
 
             # And/or change the update behavior

--- a/src/pyscaffold/api/helpers.py
+++ b/src/pyscaffold/api/helpers.py
@@ -4,6 +4,7 @@ Useful functions for manipulating the action list and project structure.
 """
 
 from copy import deepcopy
+from pathlib import PurePath
 
 from ..exceptions import ActionNotFound
 from ..log import logger
@@ -40,15 +41,17 @@ def modify(struct, path, modifier=_id_func, update_rule=None):
     Args:
         struct (dict): project representation as (possibly) nested
             :obj:`dict`. See :obj:`~.merge`.
-        path (str or list): file path relative to the structure root.
-            The directory separator should be ``/`` (forward slash) if
-            present.
-            Alternatively, a list with the parts of the path can be
-            provided, ordered from the structure root to the file itself.
-            The following examples are equivalent::
+
+        path (os.PathLike): path-like string or object relative to the
+            structure root. The following examples are equivalent::
+
+                from pathlib import PurePath
 
                 'docs/api/index.html'
-                ['docs', 'api', 'index.html']
+                PurePath('docs', 'api', 'index.html')
+
+            *Deprecated* - Alternatively, a list with the parts of the path can
+            be provided, ordered from the structure root to the file itself.
 
         modifier (callable): function (or callable object) that receives the
             old content as argument and returns the new content.
@@ -69,10 +72,16 @@ def modify(struct, path, modifier=_id_func, update_rule=None):
     Note:
         Use an empty string as content to ensure a file is created empty
         (``None`` contents will not be created).
+
+    Warning:
+        *Deprecation Notice* - In the next major release, the usage of lists
+        for the ``path`` argument will result in an error. Please use
+        :obj:`pathlib.PurePath` instead.
     """
-    # Ensure path is a list.
-    if isinstance(path, str):
-        path = path.split('/')
+    # Retrieve a list of parts from a path-like object
+    if not isinstance(path, (list, tuple)):
+        # TODO: Remove conditional for v4 (always do the following)
+        path = PurePath(path).parts
 
     # Walk the entire path, creating parents if necessary.
     root = deepcopy(struct)
@@ -101,18 +110,21 @@ def ensure(struct, path, content=None, update_rule=None):
     Args:
         struct (dict): project representation as (possibly) nested
             :obj:`dict`. See :obj:`~.merge`.
-        path (str or list): file path relative to the structure root.
-            The directory separator should be ``/`` (forward slash) if
-            present.
-            Alternatively, a list with the parts of the path can be
-            provided, ordered from the structure root to the file itself.
-            The following examples are equivalent::
+
+        path (os.PathLike): path-like string or object relative to the
+            structure root. The following examples are equivalent::
+
+                from pathlib import PurePath
 
                 'docs/api/index.html'
-                ['docs', 'api', 'index.html']
+                PurePath('docs', 'api', 'index.html')
+
+            *Deprecated* - Alternatively, a list with the parts of the path can
+            be provided, ordered from the structure root to the file itself.
 
         content (str): file text contents, ``None`` by default.
             The old content is preserved if ``None``.
+
         update_rule: see :class:`~.FileOp`, ``None`` by default
 
     Returns:
@@ -120,6 +132,11 @@ def ensure(struct, path, content=None, update_rule=None):
 
     Note:
         Use an empty string as content to ensure a file is created empty.
+
+    Warning:
+        *Deprecation Notice* - In the next major release, the usage of lists
+        for the ``path`` argument will result in an error. Please use
+        :obj:`pathlib.PurePath` instead.
     """
     modifier = _id_func if content is None else (lambda _: content)
     return modify(struct, path, modifier, update_rule)
@@ -131,22 +148,30 @@ def reject(struct, path):
     Args:
         struct (dict): project representation as (possibly) nested
             :obj:`dict`. See :obj:`~.merge`.
-        path (str or list): file path relative to the structure root.
-            The directory separator should be ``/`` (forward slash) if
-            present.
-            Alternatively, a list with the parts of the path can be
-            provided, ordered from the structure root to the file itself.
-            The following examples are equivalent::
+
+        path (os.PathLike): path-like string or object relative to the
+            structure root. The following examples are equivalent::
+
+                from pathlib import PurePath
 
                 'docs/api/index.html'
-                ['docs', 'api', 'index.html']
+                PurePath('docs', 'api', 'index.html')
+
+            *Deprecated* - Alternatively, a list with the parts of the path can
+            be provided, ordered from the structure root to the file itself.
 
     Returns:
         dict: modified project tree representation
+
+    Warning:
+        *Deprecation Notice* - In the next major release, the usage of lists
+        for the ``path`` argument will result in an error. Please use
+        :obj:`pathlib.PurePath` instead.
     """
-    # Ensure path is a list.
-    if isinstance(path, str):
-        path = path.split('/')
+    # Retrieve a list of parts from a path-like object
+    if not isinstance(path, (list, tuple)):
+        # TODO: Remove conditional for v4 (always do the following)
+        path = PurePath(path).parts
 
     # Walk the entire path, creating parents if necessary.
     root = deepcopy(struct)

--- a/src/pyscaffold/api/helpers.py
+++ b/src/pyscaffold/api/helpers.py
@@ -79,15 +79,17 @@ def modify(struct, path, modifier=_id_func, update_rule=None):
         :obj:`pathlib.PurePath` instead.
     """
     # Retrieve a list of parts from a path-like object
-    if not isinstance(path, (list, tuple)):
+    if isinstance(path, (list, tuple)):
+        path_parts = path
+    else:
         # TODO: Remove conditional for v4 (always do the following)
-        path = PurePath(path).parts
+        path_parts = PurePath(path).parts
 
     # Walk the entire path, creating parents if necessary.
     root = deepcopy(struct)
     last_parent = root
-    name = path[-1]
-    for parent in path[:-1]:
+    name = path_parts[-1]
+    for parent in path_parts[:-1]:
         last_parent = last_parent.setdefault(parent, {})
 
     # Get the old value if existent.
@@ -169,15 +171,17 @@ def reject(struct, path):
         :obj:`pathlib.PurePath` instead.
     """
     # Retrieve a list of parts from a path-like object
-    if not isinstance(path, (list, tuple)):
+    if isinstance(path, (list, tuple)):
+        path_parts = path
+    else:
         # TODO: Remove conditional for v4 (always do the following)
-        path = PurePath(path).parts
+        path_parts = PurePath(path).parts
 
     # Walk the entire path, creating parents if necessary.
     root = deepcopy(struct)
     last_parent = root
-    name = path[-1]
-    for parent in path[:-1]:
+    name = path_parts[-1]
+    for parent in path_parts[:-1]:
         if parent not in last_parent:
             return root  # one ancestor already does not exist, do nothing
         last_parent = last_parent[parent]

--- a/src/pyscaffold/extensions/no_skeleton.py
+++ b/src/pyscaffold/extensions/no_skeleton.py
@@ -3,6 +3,8 @@
 Extension that omits the creation of file `skeleton.py`
 """
 
+from pathlib import PurePath as Path
+
 from ..api import Extension, helpers
 
 
@@ -35,8 +37,8 @@ class NoSkeleton(Extension):
             struct, opts: updated project representation and options
         """
         # Namespace is not yet applied so deleting from package is enough
-        file = [opts['project'], 'src', opts['package'], 'skeleton.py']
+        file = Path(opts['project'], 'src', opts['package'], 'skeleton.py')
         struct = helpers.reject(struct, file)
-        file = [opts['project'], 'tests', 'test_skeleton.py']
+        file = Path(opts['project'], 'tests', 'test_skeleton.py')
         struct = helpers.reject(struct, file)
         return struct, opts

--- a/tests/api/test_helpers.py
+++ b/tests/api/test_helpers.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from pathlib import PurePath as Path
+
 import pytest
 
 from pyscaffold import api
@@ -68,7 +70,7 @@ def test_modify_non_existent():
     def _modifier(old):
         assert old is None
         return "1"
-    structure = helpers.modify(structure, ["a", "c"], _modifier)
+    structure = helpers.modify(structure, Path("a", "c"), _modifier)
 
     # But the result of the modifier function should be included in the tree
     assert structure["a"]["c"] == "1"
@@ -79,7 +81,7 @@ def test_modify_no_function():
     structure = {"a": {"b": "0"}}
 
     # When the modify helper is called with an update rule but no modifier
-    structure = helpers.modify(structure, ["a", "b"],
+    structure = helpers.modify(structure, "a/b",
                                update_rule=helpers.NO_CREATE)
 
     # Then the content should remain the same
@@ -92,7 +94,7 @@ def test_ensure_nested():
     structure = {"a": {"b": "0"}}
     # that is added using the ensure method,
     structure = helpers.ensure(structure,
-                               ["a", "c", "d", "e", "f"], content="1")
+                               Path("a", "c", "d", "e", "f"), content="1")
     # then all the necessary parent folder should be included
     assert isinstance(structure["a"]["c"], dict)
     assert isinstance(structure["a"]["c"]["d"], dict)
@@ -105,7 +107,7 @@ def test_ensure_overriden():
     # When the original structure contains a leaf
     structure = {"a": {"b": "0"}}
     # that is overridden using the ensure method,
-    structure = helpers.ensure(structure, ["a", "b"], content="1")
+    structure = helpers.ensure(structure, Path("a", "b"), content="1")
     # and the file content should be overridden
     assert structure["a"]["b"] == "1"
 
@@ -122,7 +124,7 @@ def test_reject():
     # When the original structure contain a leaf
     structure = {"a": {"b": {"c": "0"}}}
     # that is removed using the reject method,
-    structure = helpers.reject(structure, ["a", "b", "c"])
+    structure = helpers.reject(structure, Path("a", "b", "c"))
     # then the structure should not contain the file
     assert "c" not in structure["a"]["b"]
 


### PR DESCRIPTION
This PR address #211, by adding support to `os.PathLike` objects.

At this point `os.PathLike`, `str`, `list` and `tuple` are accepted (the PR just add supports, but not remove).
As a TODO for v4, we have to drop support for `list` and `tuple` .